### PR TITLE
Fix enumopencl for issue #17

### DIFF
--- a/samples/core/enumopencl/main.cpp
+++ b/samples/core/enumopencl/main.cpp
@@ -209,6 +209,7 @@ static cl_int PrintDeviceInfoSummary(cl_device_id* devices, size_t numDevices)
         deviceName = NULL;
         deviceVendor = NULL;
         deviceVersion = NULL;
+        deviceProfile = NULL;
         driverVersion = NULL;
     }
 


### PR DESCRIPTION
Fix issue #17 by setting `deviceProfile = NULL;` in the code block with the other char arrays.