### PR TITLE
enhance the CMake function to add samples

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2021 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,59 @@
 # limitations under the License.
 
 if(CMAKE_CONFIGURATION_TYPES)
-    set(SAMPLE_CONFIGS ${CMAKE_CONFIGURATION_TYPES})
+    set(OPENCL_SAMPLE_CONFIGS ${CMAKE_CONFIGURATION_TYPES})
 else()
-    set(SAMPLE_CONFIGS ${CMAKE_BUILD_TYPE})
+    set(OPENCL_SAMPLE_CONFIGS ${CMAKE_BUILD_TYPE})
 endif()
 
-# Usage: add_sample(name source0 [source1] ...)
-function(add_sample name)
-  add_executable(${name} ${ARGN})
-  target_include_directories(${name} PRIVATE ${OPENCL_SDK_INCLUDE_DIRS})
-  target_link_libraries(${name} OpenCL)
-  foreach(config ${SAMPLE_CONFIGS})
-    install(TARGETS ${name} CONFIGURATIONS ${config} DESTINATION ${config})
-  endforeach()
+# Usage:
+# add_sample(
+#     TEST              # optional, adds a ctest for the sample
+#     TARGET <name>     # specifies the name of the sample
+#     VERSION <number>  # specifies the OpenCL version for the sample
+#     CATEGORY <name>   # optional, specifies a category for the sample
+#     SOURCES <file0> <file1> ... # specifies source files for the sample
+#     KERNELS <file0> <file1> ... # optional, specifies kernel files for the sample
+#     INCLUDES <dir0> <dir1> ...  # optional, specifies additional include directories for the sample
+#     LIBS <lib0> <lib1> ...      # optional, specifies additional libraries for the sample
+# )
+function(add_sample)
+    set(options TEST)
+    set(one_value_args TARGET VERSION CATEGORY)
+    set(multi_value_args SOURCES KERNELS INCLUDES LIBS)
+    cmake_parse_arguments(OPENCL_SAMPLE
+        "${options}" "${one_value_args}" "${multi_value_args}"
+        ${ARGN}
+    )
+
+    if(NOT OPENCL_SAMPLE_VERSION)
+        message(STATUS "No OpenCL version specified for sample ${OPENCL_SAMPLE_TARGET}, using OpenCL 3.0.")
+        set(OPENCL_SAMPLE_VERSION 300)
+    endif()
+
+    add_executable(${OPENCL_SAMPLE_TARGET} ${OPENCL_SAMPLE_SOURCES})
+
+    target_include_directories(${OPENCL_SAMPLE_TARGET} PRIVATE ${OPENCL_SDK_INCLUDE_DIRS} ${OPENCL_SAMPLE_INCLUDES})
+    target_link_libraries(${OPENCL_SAMPLE_TARGET} OpenCL ${OPENCL_SAMPLE_LIBS})
+
+    target_compile_definitions(${OPENCL_SAMPLE_TARGET} PRIVATE CL_HPP_ENABLE_EXCEPTIONS)
+    target_compile_definitions(${OPENCL_SAMPLE_TARGET} PRIVATE CL_TARGET_OPENCL_VERSION=${OPENCL_SAMPLE_VERSION})
+    target_compile_definitions(${OPENCL_SAMPLE_TARGET} PRIVATE CL_HPP_TARGET_OPENCL_VERSION=${OPENCL_SAMPLE_VERSION})
+    target_compile_definitions(${OPENCL_SAMPLE_TARGET} PRIVATE CL_HPP_MINIMUM_OPENCL_VERSION=${OPENCL_SAMPLE_VERSION})
+    if (WIN32)
+        target_compile_definitions(${OPENCL_SAMPLE_TARGET} PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+
+    set_target_properties(${OPENCL_SAMPLE_TARGET} PROPERTIES FOLDER "Samples/${OPENCL_SAMPLE_CATEGORY}/${OPENCL_SAMPLE_TARGET}")
+
+    foreach(CONFIG ${OPENCL_SAMPLE_CONFIGS})
+        install(TARGETS ${OPENCL_SAMPLE_TARGET} CONFIGURATIONS ${CONFIG} DESTINATION ${CONFIG})
+        install(FILES ${OPENCL_SAMPLE_KERNELS} CONFIGURATIONS ${CONFIG} DESTINATION ${CONFIG})
+    endforeach()
+    if(OPENCL_SAMPLE_TEST)
+        add_test(NAME ${OPENCL_SAMPLE_TARGET} COMMAND ${OPENCL_SAMPLE_TARGET})
+    endif()
 endfunction()
+
 
 add_subdirectory(core)

--- a/samples/core/copybuffer/CMakeLists.txt
+++ b/samples/core/copybuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2021 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(SAMPLE_NAME copybuffer)
-
-add_sample(${SAMPLE_NAME} main.cpp)
-
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_ENABLE_EXCEPTIONS)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_TARGET_OPENCL_VERSION=120)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_TARGET_OPENCL_VERSION=120)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_MINIMUM_OPENCL_VERSION=120)
-
+add_sample(
+    TEST
+    TARGET copybuffer
+    VERSION 120
+    SOURCES main.cpp)

--- a/samples/core/copybufferkernel/CMakeLists.txt
+++ b/samples/core/copybufferkernel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2021 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(SAMPLE_NAME copybufferkernel)
-
-add_sample(${SAMPLE_NAME} main.cpp)
-
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_ENABLE_EXCEPTIONS)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_TARGET_OPENCL_VERSION=120)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_TARGET_OPENCL_VERSION=120)
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_HPP_MINIMUM_OPENCL_VERSION=120)
-
+add_sample(
+    TEST
+    TARGET copybufferkernel
+    VERSION 120
+    SOURCES main.cpp)

--- a/samples/core/enumopencl/CMakeLists.txt
+++ b/samples/core/enumopencl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Khronos Group Inc.
+# Copyright (c) 2021 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(SAMPLE_NAME enumopencl)
-
-add_sample(${SAMPLE_NAME} main.cpp)
-
-target_compile_definitions(${SAMPLE_NAME} PRIVATE CL_TARGET_OPENCL_VERSION=120)
-
+add_sample(
+    TEST
+    TARGET enumopencl
+    VERSION 120
+    SOURCES main.cpp)


### PR DESCRIPTION
Fixes #22.

I ended up keeping `TEST` since I've found it useful, but I don't remind removing it if desired.

(It doesn't do anythign right now anyhow, since the OpenCL SDK currently doesn't enable testing.)