### PR TITLE
Add OpenCL ruby samples

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -91,8 +91,8 @@ jobs:
             time python $i
           done
 
-  buildruby:
-    name: Build Ruby ${{ matrix.os }}
+  checkruby:
+    name: Check Ruby Samples ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -90,3 +90,28 @@ jobs:
             echo "-----------------------------------------------------------------------"
             time python $i
           done
+
+  buildruby:
+    name: Build Ruby ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install Ruby and POCL
+        run: sudo apt install pocl-opencl-icd
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Install OpenCL Ruby Bindings and RuboCop
+        run: gem install --user-install opencl_ruby_ffi rubocop
+      - name: Check Ruby Syntax
+        run: |
+          export PATH=`ruby -r rubygems -e 'puts Gem.user_dir'`/bin:$PATH
+          rubocop
+        working-directory: ruby
+      - name: Run Ruby Samples
+        run: rake test
+        working-directory: ruby

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,15 @@
+# Ruby Samples
+
+## Sample Purpose
+
+Those samples reproduce the core samples using Ruby. They accept the same
+options, please refer to each core sample `README.md` for documentation.
+
+## Prerequisites
+
+In addition to a working Ruby installation, as well as Ruby development files,
+those samples require the `opencl_ruby_ffi` Ruby bindings. The bindings can be
+installed using:
+```bash
+gem install --user-install opencl_ruby_ffi
+```

--- a/ruby/copybuffer/copybuffer.rb
+++ b/ruby/copybuffer/copybuffer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+options = { platform: 0, device: 0 }
+OptionParser.new do |parser|
+  parser.banner = "Usage: ruby #{File.basename($PROGRAM_NAME)} [options]"
+  parser.on('-p', '--platform INDEX', Integer, 'Index of the platform to use (default 0)')
+  parser.on('-d', '--device INDEX', Integer, 'Index of the device to use (default 0)')
+end.parse!(into: options)
+
+require 'opencl_ruby_ffi'
+
+buffer_size = 1024 * 1024
+
+p = OpenCL.platforms[options[:platform]]
+raise "Invalid platform index #{options[:platform]}" unless p
+
+d = p.devices[options[:device]]
+raise "Invalid device index #{options[:device]}" unless d
+
+puts "Running on platform: #{p.name}"
+puts "Running on device: #{d.name}"
+
+c = OpenCL.create_context(d)
+q = c.create_command_queue(d)
+
+device_src = c.create_buffer(buffer_size * OpenCL::UInt.size, flags: OpenCL::Mem::ALLOC_HOST_PTR)
+device_dst = c.create_buffer(buffer_size * OpenCL::UInt.size, flags: OpenCL::Mem::ALLOC_HOST_PTR)
+
+_, host_ptr = q.enqueue_map_buffer(device_src, OpenCL::MapFlags::WRITE_INVALIDATE_REGION, blocking: true)
+host_ptr.write_array_of_uint(buffer_size.times.to_a)
+q.enqueue_unmap_mem_object(device_src, host_ptr)
+
+q.enqueue_copy_buffer(device_src, device_dst)
+
+_, host_ptr = q.enqueue_map_buffer(device_dst, OpenCL::MapFlags::READ, blocking: true)
+result = host_ptr.read_array_of_uint(buffer_size)
+buffer_size.times do |i|
+  raise "invalid copy: wanted #{i}, got #{result[i]}" unless result[i] == i
+end
+q.enqueue_unmap_mem_object(device_dst, host_ptr)
+
+puts 'Success.'

--- a/ruby/copybufferkernel/copybufferkernel.rb
+++ b/ruby/copybufferkernel/copybufferkernel.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+options = { platform: 0, device: 0 }
+OptionParser.new do |parser|
+  parser.banner = "Usage: ruby #{File.basename($PROGRAM_NAME)} [options]"
+  parser.on('-p', '--platform INDEX', Integer, 'Index of the platform to use (default 0)')
+  parser.on('-d', '--device INDEX', Integer, 'Index of the device to use (default 0)')
+end.parse!(into: options)
+
+require 'opencl_ruby_ffi'
+require 'narray_ffi'
+
+kernel_string = <<~CLC
+  kernel void CopyBuffer( global uint* dst, global uint* src )
+  {
+      uint id = get_global_id(0);
+      dst[id] = src[id];
+  }
+CLC
+
+buffer_size = 1024 * 1024
+
+p = OpenCL.platforms[options[:platform]]
+raise "Invalid platform index #{options[:platform]}" unless p
+
+d = p.devices[options[:device]]
+raise "Invalid device index #{options[:device]}" unless d
+
+puts "Running on platform: #{p.name}"
+puts "Running on device: #{d.name}"
+
+begin
+  c = OpenCL.create_context(d)
+  q = c.create_command_queue(d)
+
+  program = c.create_program_with_source(kernel_string)
+  program.build
+  device_src = c.create_buffer(buffer_size * OpenCL::UInt.size, flags: OpenCL::Mem::ALLOC_HOST_PTR)
+  device_dst = c.create_buffer(buffer_size * OpenCL::UInt.size, flags: OpenCL::Mem::ALLOC_HOST_PTR)
+
+  _, host_ptr = q.enqueue_map_buffer(device_src, OpenCL::MapFlags::WRITE_INVALIDATE_REGION, blocking: true)
+  arr = NArray.to_na(host_ptr, NArray::INT)
+  buffer_size.times { |i| arr[i] = i }
+  q.enqueue_unmap_mem_object(device_src, host_ptr)
+
+  program.CopyBuffer(q, [buffer_size], device_dst, device_src)
+
+  _, host_ptr = q.enqueue_map_buffer(device_dst, OpenCL::MapFlags::READ, blocking: true)
+  arr = NArray.to_na(host_ptr, NArray::INT)
+  buffer_size.times do |i|
+    raise "invalid copy: wanted #{i}, got #{arr[i]}" unless arr[i] == i
+  end
+  q.enqueue_unmap_mem_object(device_dst, host_ptr)
+
+  puts 'Success.'
+rescue OpenCL::Error::BUILD_PROGRAM_FAILURE
+  puts 'Compilation of program failed:'
+  program.build_log.each do |device, log|
+    puts " - #{device.name}:"
+    puts log
+  end
+  puts 'Expected Failure on MacOS...'
+end

--- a/ruby/enumopencl/enumopencl.rb
+++ b/ruby/enumopencl/enumopencl.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'opencl_ruby_ffi'
+require 'yaml'
+
+puts YAML.dump(
+  { 'platforms' => OpenCL.platforms.collect do |p|
+    { 'name' => p.name,
+      'vendor' => p.vendor,
+      'version' => p.version,
+      'devices' => p.devices.collect do |d|
+        { 'name' => d.name,
+          'type' => d.type.to_s,
+          'vendor' => d.vendor,
+          'version' => d.version,
+          'profile' => d.profile,
+          'driver_version' => d.driver_version }
+      end }
+  end }
+)

--- a/ruby/rakefile
+++ b/ruby/rakefile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.pattern = '**/*.rb'
+end


### PR DESCRIPTION
This pull request adds Ruby samples reproducing the C/C++ samples already present in the SDK.
It also adds CI on Ubuntu and MacOS. If an OpenCL platform could be installed on windows, we could test it there as the bindings have been reported to work on windows as well.