### PR TITLE
Ignore generated files from CMake, VS, XCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,24 @@ install/
 # vim
 *~
 .*.sw[op]
+
+# MacOS
+.DS_Store
+*.xcodeproj/
+
+# Visual Studio
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.sln
+
+# CMake
+CMakeFiles/
+CMakeScripts/
+CMakeCache.txt
+cmake_install.cmake
+
+# Build
+[Dd]ebug/
+[Rr]elease/
+*.dir


### PR DESCRIPTION
This makes building the CMake project inside of the source folder (instead of inside of the build/ folder) more convenient