### PR TITLE
Initial release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  windows-binary:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        VER: [v143]
+        GEN: [Visual Studio 17 2022]
+        BIN: [x64, x86]
+
+    steps:
+    - name: Checkout OpenCL-SDK
+      uses: actions/checkout@v2
+
+    - name: Initialize git submodules
+      shell: pwsh
+      run: |
+        & git submodule init
+        & git submodule update
+
+    - name: Create Build Environment
+      shell: pwsh
+      run: |
+        # Parallelize MSBuild across projects
+        [Environment]::SetEnvironmentVariable('UseMultiToolTask', 'true', [EnvironmentVariableTarget]::User)
+
+    - name: Configure
+      shell: pwsh
+      run: |
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        & cmake `
+          -G '${{matrix.GEN}}' `
+          -A ${BIN} `
+          -T ${{matrix.VER}} `
+          -S "${env:GITHUB_WORKSPACE}" `
+          -B "${env:GITHUB_WORKSPACE}\build" `
+          -D BUILD_DOCS=OFF `
+          -D BUILD_TESTING=OFF `
+          -D BUILD_TESTS=OFF `
+          -D OPENCL_SDK_BUILD_SAMPLES=OFF `
+          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF
+
+    - name: Build
+      shell: pwsh
+      run: |
+        & cmake `
+          --build "${env:GITHUB_WORKSPACE}\build" `
+          --config Release `
+          -- `
+          /verbosity:minimal `
+          /maxCpuCount `
+          /noLogo
+
+    - name: Install
+      shell: pwsh
+      run: |
+        & cmake `
+          --install "${env:GITHUB_WORKSPACE}\build" `
+          --prefix "${env:GITHUB_WORKSPACE}\install" `
+          --config Release
+
+    - name: Package Binary
+      shell: pwsh
+      run: |
+        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'win32'} else {'win64'}
+        & cpack `
+          --config "${env:GITHUB_WORKSPACE}\build\CPackConfig.cmake" `
+          -G ZIP `
+          -C Release `
+          -B "${env:GITHUB_WORKSPACE}\package" `
+        Rename-Item "${env:GITHUB_WORKSPACE}\package\OpenCL-SDK-${{github.ref_name}}-${BIN}.zip" "OpenCL-SDK-${{github.ref_name}}-Win-${{matrix.BIN}}.zip"
+
+    - name: Release Binary
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: true
+        files: |
+          package/OpenCL-SDK-${{github.ref_name}}-Win-${{matrix.BIN}}.zip
+
+  source:
+    name: Source Release (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        OS: [ubuntu-20.04, windows-2022]
+
+    steps:
+    - name: Checkout OpenCL-SDK
+      uses: actions/checkout@v2
+
+    - name: Initialize git submodules
+      shell: pwsh
+      run: |
+        & git submodule init
+        & git submodule update
+
+    - name: Configure
+      shell: pwsh
+      run: |
+        & cmake `
+          -S "${env:GITHUB_WORKSPACE}" `
+          -B "${env:GITHUB_WORKSPACE}\build" `
+          -D BUILD_DOCS=OFF `
+          -D BUILD_TESTING=OFF `
+          -D BUILD_TESTS=OFF `
+          -D OPENCL_SDK_BUILD_SAMPLES=OFF `
+          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
+          -D CPACK_SOURCE_IGNORE_FILES="/\\.git/;/\\.gitignore;/\\.gitmodules;/\\.gitlab/;/\\.github/;/\\.reuse/;/\\.appveyor.yml;/build/;/install/;/package/"
+
+    - name: Package Source
+      shell: pwsh
+      run: |
+        $Generator = if('${{matrix.OS}}' -match 'windows') {'ZIP'} else {'TGZ'}
+        & cpack `
+          --config "${env:GITHUB_WORKSPACE}\build\CPackSourceConfig.cmake" `
+          -G $Generator `
+          -C Release `
+          -B "${env:GITHUB_WORKSPACE}\package"
+
+    - name: Release Source
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: true
+        files: |
+          package/OpenCL-SDK-${{github.ref_name}}-Source.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.0)
 set(CMAKE_CXX_STANDARD 14)
 
 project(OpenCL-SDK
-  VERSION 1.0
+  VERSION 2022.03.09
   LANGUAGES
     C CXX
 )
@@ -102,3 +102,5 @@ install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCL/OpenCLConfigVersion.cmake
   DESTINATION ${config_package_location}
 )
+
+include(CPack)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,7 +50,19 @@ Submodules may have moved to a different commit hash due to the previous step. T
 
 ```
 git commit -a -m "Bump submodules hashes"
-git push origin main
+```
+
+## Update project version
+
+Update the project version in CMake
+
+```cmake
+project(OpenCL-SDK
+  VERSION YYYY.MM.DD
+```
+
+```
+git commit -a -m "Update project version"
 ```
 
 ## Tag SDK

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,61 @@
+# Release process
+
+To release a new version of the SDK, follow the process in a recursively cloned repo:
+
+> Throughout the guide `<remote_name>` refers to the https://github.com/KhronosGroup hosted remotes. Your dev environment may not refer to these as `origin` but any other name, for eg. `upstream`. Update commands as needed.
+
+## Checkout tip of main
+
+With a clean workspace and empty stage, issue the following.
+
+```
+git pull <remote_name>
+git checkout <remote_name>/main
+```
+
+## Update submodules
+
+Should tip of main have updated submodule remotes, the SDK needs those changes. (This part likely does nothing.)
+
+```
+git submodule update --remote
+```
+
+## Tag OpenCL projects
+
+In the external folder, tag the OpenCL-related projects with the current date using `vYYYY.MM.DD` format in dep order.
+
+1. OpenCL-Headers
+2. OpenCL-ICD-Loader
+3. OpenCL-CLHPP
+
+> Note: the aim is that OpenCL-Layers in time will become a submodule/component of the SDK
+
+In each of these repos, issue:
+
+```
+git pull origin
+git checkout origin/main
+git tag vYYYY.MM.DD
+git push origin vYYYY.MM.DD
+```
+
+> Note 1: Remote name `origin` isn't an oversight, the default remote name for submodules is `origin`.
+>
+> Note 2: Compatibility between packages is guaranteed manually. CI for each project fetches newest `main` and not using the same tag. Pushing tags in dep order is important to guarantee that when CI runs on pushing tags in these repos, tests are run using the correct versions of their deps.
+
+## Update submodule hashes
+
+Submodules may have moved to a different commit hash due to the previous step. The SDK wants to pick up all those changes (if it hasn't already been done). If `git status` shows, changes, push the changes.
+
+```
+git commit -a -m "Bump submodules hashes"
+git push origin main
+```
+
+## Tag SDK
+
+```
+git tag vYYYY.MM.DD
+git push <remote_name> vYYYY.MM.DD
+```


### PR DESCRIPTION
This PR holds automation for source and binary releases of the SDK whenever a version tag is applied. It only creates a draft release which then has to be manually verified and published. (The UI is fairly straightforward) A draft release which runs after adding a version tag look like [this](https://github.com/StreamHPC/OpenCL-SDK/releases/tag/untagged-1c69145d6331af93ae5b).

Currently only Windows binary releases are done, because that is the platform which necessitates this the most, but later iterations can expand on that. (I would call on people actually shipping Linux releases, not just libraries to tune in on what is the optimal set of release build flags on Linux.) Submodule source files are included in the source tarballs.

_(Unfortunately I can't remove the automatic source tarball assets, those are always added by GitHub and can't be removed. I already [reached out to the community](https://github.community/t/remove-overwrite-default-source-tarball-assets/235118) if that's possible, but that is more or less polish atop the feature. It's important, we don't want people downloading the wrong stuff, but there's really no way around it, or not that I know of.)_