### PR TITLE
Fix UtilsCpp debug install

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -83,10 +83,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ matrix.deps }}' -eq 'vcpkg') {
-            git clone https://github.com/Microsoft/vcpkg.git
-            .\vcpkg\bootstrap-vcpkg.bat
-            .\vcpkg\vcpkg.exe --triplet=x64-windows install sfml tclap glm glew stb
-            $TOOLCHAIN_ARG='-D CMAKE_TOOLCHAIN_FILE=.\vcpkg\scripts\buildsystems\vcpkg.cmake'
+            Get-ChildItem Env:\
+            & ${env:VCPKG_ROOT}\vcpkg.exe --triplet=x64-windows install sfml tclap glm glew stb
+            $TOOLCHAIN_ARG="-D CMAKE_TOOLCHAIN_FILE=${env:VCPKG_ROOT}\scripts\buildsystems\vcpkg.cmake"
           } else {
             $TOOLCHAIN_ARG=''
           }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,6 +55,7 @@ foreach(UTIL_LIB_NAME IN ITEMS Utils UtilsCpp)
       INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
       FOLDER "Libraries/${UTIL_LIB_NAME}"
       EXPORT_NAME ${UTIL_LIB_NAME}
+      DEBUG_POSTFIX d
   )
 
   install(

--- a/test/cmake/pkgconfig/platformenum/CMakeLists.txt
+++ b/test/cmake/pkgconfig/platformenum/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(PkgConfigTest)
+project(PkgConfigTest-PlatformEnum)
 
 find_package(OpenCL
   REQUIRED
@@ -14,7 +14,7 @@ find_package(OpenCL
 # Test consuming from C++ source files
 
 add_executable(${PROJECT_NAME}_cpp
-  ../platformenum.cpp
+  ../../platformenum.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_cpp
@@ -38,7 +38,7 @@ add_test(
 # Test consuming from C source files
 
 add_executable(${PROJECT_NAME}_c
-  ../platformenum.c
+  ../../platformenum.c
 )
 
 target_link_libraries(${PROJECT_NAME}_c

--- a/test/cmake/pkgconfig/useutil/CMakeLists.txt
+++ b/test/cmake/pkgconfig/useutil/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(PkgConfigTest-UseUtil)
+
+find_package(OpenCL
+  REQUIRED
+  CONFIG
+  COMPONENTS
+    Utils
+    UtilsCpp
+    HeadersCpp
+    Headers
+    OpenCL
+)
+
+# Test consuming from C++ source files
+
+add_executable(${PROJECT_NAME}_cpp
+  ../../useutil.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_cpp
+  PRIVATE
+    OpenCL::UtilsCpp
+    OpenCL::HeadersCpp
+    OpenCL::Headers
+    OpenCL::OpenCL
+)
+
+target_compile_definitions(${PROJECT_NAME}_cpp
+  PRIVATE
+    CL_HPP_ENABLE_EXCEPTIONS
+    CL_HPP_TARGET_OPENCL_VERSION=300
+)
+
+add_test(
+  NAME ${PROJECT_NAME}_cpp
+  COMMAND ${PROJECT_NAME}_cpp
+)
+
+# Test consuming from C source files
+
+add_executable(${PROJECT_NAME}_c
+  ../../useutil.c
+)
+
+target_link_libraries(${PROJECT_NAME}_c
+  PRIVATE
+    OpenCL::Utils
+    OpenCL::Headers
+    OpenCL::OpenCL
+)
+
+target_compile_definitions(${PROJECT_NAME}_c
+  PRIVATE
+    CL_TARGET_OPENCL_VERSION=300
+)
+
+add_test(
+  NAME ${PROJECT_NAME}_c
+  COMMAND ${PROJECT_NAME}_c
+)

--- a/test/cmake/useutil.c
+++ b/test/cmake/useutil.c
@@ -1,0 +1,26 @@
+// OpenCL includes
+#include <CL/cl.h>
+
+// C standard includes
+#include <stdio.h>
+
+#ifdef _MSC_VER
+#define print(...) printf_s(__VA_ARGS__)
+#else
+#define print(...) printf(__VA_ARGS__)
+#endif
+
+int main()
+{
+    cl_int CL_err = CL_SUCCESS;
+    cl_uint numPlatforms = 0;
+
+    CL_err = clGetPlatformIDs(0, NULL, &numPlatforms);
+
+    if (CL_err == CL_SUCCESS)
+        print("%u platform(s) found\n", numPlatforms);
+    else
+        print("clGetPlatformIDs(%i)\n", CL_err);
+
+    return 0;
+}

--- a/test/cmake/useutil.cpp
+++ b/test/cmake/useutil.cpp
@@ -1,0 +1,35 @@
+#include <CL/opencl.hpp>
+
+#include <CL/Utils/Utils.hpp>
+
+#include <vector> // std::vector
+#include <exception> // std::runtime_error, std::exception
+#include <iostream> // std::cout
+#include <cstdlib> // EXIT_FAILURE
+
+int main(int argc, char* argv[])
+{
+    try
+    {
+        cl::Context context =
+            cl::util::get_context(argc > 1 ? std::atoi(argv[1]) : 0,
+
+            );
+    } catch (cl::Error& error) // If any OpenCL error occurs
+    {
+        if (error.err() == CL_PLATFORM_NOT_FOUND_KHR)
+        {
+            std::cout << "No OpenCL platform found." << std::endl;
+            std::exit(EXIT_SUCCESS);
+        }
+        else
+        {
+            std::cerr << error.what() << "(" << error.err() << ")" << std::endl;
+            std::exit(error.err());
+        }
+    } catch (std::exception& error) // If STL/CRT error occurs
+    {
+        std::cerr << error.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}

--- a/test/cmake/useutil.cpp
+++ b/test/cmake/useutil.cpp
@@ -11,10 +11,9 @@ int main(int argc, char* argv[])
 {
     try
     {
-        cl::Context context =
-            cl::util::get_context(argc > 1 ? std::atoi(argv[1]) : 0,
-
-            );
+        cl::Context context = cl::util::get_context(
+            argc > 1 ? std::atoi(argv[1]) : 0,
+            argc > 2 ? std::atoi(argv[2]) : 0, CL_DEVICE_TYPE_ALL);
     } catch (cl::Error& error) // If any OpenCL error occurs
     {
         if (error.err() == CL_PLATFORM_NOT_FOUND_KHR)


### PR DESCRIPTION
On Windows, Debug and Release C++ libraries aren't link compatible. If the name of a library on disk is the same for both Debug and Release builds, they can't be installed side-by-side and makes it much harder to consume them for development purposes where both versions would be needed. This PR addresses that by changing the name of the utility libraries on disk for Debug builds, so they can coexist with Release artifacts.

_(Note that CI doesn't test it yet, because the OpenCL-SDK's CI is still fairly rudimentary. This feature still requires manual testing.)_