### PR TITLE
Release fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,24 +48,14 @@ jobs:
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
           -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF
 
-    - name: Build
+    - name: Check version number
       shell: pwsh
       run: |
-        & cmake `
-          --build "${env:GITHUB_WORKSPACE}\build" `
-          --config Release `
-          -- `
-          /verbosity:minimal `
-          /maxCpuCount `
-          /noLogo
-
-    - name: Install
-      shell: pwsh
-      run: |
-        & cmake `
-          --install "${env:GITHUB_WORKSPACE}\build" `
-          --prefix "${env:GITHUB_WORKSPACE}\install" `
-          --config Release
+        if ( -not (`
+          Get-Content ${env:GITHUB_WORKSPACE}\CMakeCache.txt | `
+          Select-String -Pattern ('CMAKE_PROJECT_VERSION:STATIC=' + '${{github.ref_name}}'.Replace('v','')) `
+        )) `
+        { throw 'CMake project version mismatches Git tag name (without leading "v")'}
 
     - name: Package Binary
       shell: pwsh
@@ -113,14 +103,21 @@ jobs:
           -D BUILD_TESTING=OFF `
           -D BUILD_TESTS=OFF `
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
-          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
-          -D CPACK_SOURCE_IGNORE_FILES="/\\.git/;/\\.gitignore;/\\.gitmodules;/\\.gitlab/;/\\.github/;/\\.reuse/;/\\.appveyor.yml;/build/;/install/;/package/"
+          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF
+
+    - name: Check version number
+      shell: pwsh
+      run: |
+        if ( -not (`
+          Get-Content ${env:GITHUB_WORKSPACE}/CMakeCache.txt | `
+          Select-String -Pattern ('CMAKE_PROJECT_VERSION:STATIC=' + '${{github.ref_name}}'.Replace('v','')) `
+        )) `
+        { throw 'CMake project version mismatches Git tag name (without leading "v")'}
 
     - name: Package Source
       shell: pwsh
       run: |
         $Generator = if('${{matrix.OS}}' -match 'windows') {'ZIP'} else {'TGZ'}
-        $Extension = if('${{matrix.OS}}' -match 'windows') {'zip'} else {'tar.gz'}
         & cpack `
           --config "${env:GITHUB_WORKSPACE}/build/CPackSourceConfig.cmake" `
           -G $Generator `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
     - name: Configure
       shell: pwsh
       run: |
-        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
+        $Bin = if('${{matrix.BIN}}' -eq 'x86') {'Win32'} else {'x64'}
         & cmake `
           -G '${{matrix.GEN}}' `
-          -A ${BIN} `
+          -A ${Bin} `
           -T ${{matrix.VER}} `
           -S "${env:GITHUB_WORKSPACE}" `
           -B "${env:GITHUB_WORKSPACE}\build" `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           -B "${env:GITHUB_WORKSPACE}\build" `
           -D BUILD_DOCS=OFF `
           -D BUILD_TESTING=OFF `
-          -D BUILD_TESTS=OFF `
+          -D BUILD_EXAMPLES=OFF `
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
           -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
           -D CMAKE_POLICY_DEFAULT_CMP0096=NEW
@@ -113,7 +113,7 @@ jobs:
           -B "${env:GITHUB_WORKSPACE}/build" `
           -D BUILD_DOCS=OFF `
           -D BUILD_TESTING=OFF `
-          -D BUILD_TESTS=OFF `
+          -D BUILD_EXAMPLES=OFF `
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
           -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
           -D CMAKE_POLICY_DEFAULT_CMP0096=NEW

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
           -D BUILD_TESTING=OFF `
           -D BUILD_TESTS=OFF `
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
-          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF
+          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
+          -D CMAKE_POLICY_DEFAULT_CMP0096=NEW
 
     - name: Check version number
       shell: pwsh
@@ -102,7 +103,8 @@ jobs:
           -D BUILD_TESTING=OFF `
           -D BUILD_TESTS=OFF `
           -D OPENCL_SDK_BUILD_SAMPLES=OFF `
-          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF
+          -D OPENCL_ICD_LOADER_BUILD_TESTING=OFF `
+          -D CMAKE_POLICY_DEFAULT_CMP0096=NEW
 
     - name: Check version number
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       shell: pwsh
       run: |
         if ( -not (`
-          Get-Content ${env:GITHUB_WORKSPACE}\CMakeCache.txt | `
+          Get-Content ${env:GITHUB_WORKSPACE}\build\CMakeCache.txt | `
           Select-String -Pattern ('CMAKE_PROJECT_VERSION:STATIC=' + '${{github.ref_name}}'.Replace('v','')) `
         )) `
         { throw 'CMake project version mismatches Git tag name (without leading "v")'}
@@ -110,7 +110,7 @@ jobs:
       shell: pwsh
       run: |
         if ( -not (`
-          Get-Content ${env:GITHUB_WORKSPACE}/CMakeCache.txt | `
+          Get-Content ${env:GITHUB_WORKSPACE}/build/CMakeCache.txt | `
           Select-String -Pattern ('CMAKE_PROJECT_VERSION:STATIC=' + '${{github.ref_name}}'.Replace('v','')) `
         )) `
         { throw 'CMake project version mismatches Git tag name (without leading "v")'}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         # Parallelize MSBuild across projects
         [Environment]::SetEnvironmentVariable('UseMultiToolTask', 'true', [EnvironmentVariableTarget]::User)
+        [Environment]::SetEnvironmentVariable('EnforceProcessCountAcrossBuilds', 'true', [EnvironmentVariableTarget]::User)
+        [Environment]::SetEnvironmentVariable('MultiProcMaxCount', "$env:NUMBER_OF_PROCESSORS", [EnvironmentVariableTarget]::User)
 
     - name: Configure
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,18 @@ jobs:
         )) `
         { throw 'CMake project version mismatches Git tag name (without leading "v")'}
 
+    - name: Build
+      shell: pwsh
+      run: |
+        foreach ($Config in "Debug","Release") { `
+          & cmake `
+            --build "${env:GITHUB_WORKSPACE}\build" `
+            --config $Config `
+            -- `
+            /verbosity:minimal `
+            /noLogo `
+        }
+    
     - name: Package Binary
       shell: pwsh
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,14 @@ jobs:
     - name: Package Binary
       shell: pwsh
       run: |
-        $BIN = if('${{matrix.BIN}}' -eq 'x86') {'win32'} else {'win64'}
         & cpack `
           --config "${env:GITHUB_WORKSPACE}\build\CPackConfig.cmake" `
           -G ZIP `
-          -C Release `
+          -C 'Debug;Release' `
+          -D CPACK_PACKAGE_FILE_NAME='OpenCL-SDK-${{github.ref_name}}-Win-${{matrix.BIN}}' `
           -B "${env:GITHUB_WORKSPACE}\package"
-        Rename-Item "${env:GITHUB_WORKSPACE}\package\OpenCL-SDK-*.zip" "OpenCL-SDK-${{github.ref_name}}-Win-${{matrix.BIN}}.zip"
 
-    - name: Release Binary
+    - name: Upload Package
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -122,8 +121,9 @@ jobs:
           --config "${env:GITHUB_WORKSPACE}/build/CPackSourceConfig.cmake" `
           -G $Generator `
           -C Release `
+          -D CPACK_SOURCE_IGNORE_FILES="/\\.git/;/\\.gitignore;/\\.gitmodules;/\\.gitlab/;/\\.github/;/\\.reuse/;/\\.appveyor.yml;/build/;/install/;/package/" `
+          -D CPACK_PACKAGE_FILE_NAME='OpenCL-SDK-${{github.ref_name}}-Source' `
           -B "${env:GITHUB_WORKSPACE}/package"
-        Rename-Item "${env:GITHUB_WORKSPACE}/package/OpenCL-SDK-*.${Extension}" "OpenCL-SDK-${{github.ref_name}}-Source.${Extension}"
 
     - name: Release Source
       uses: softprops/action-gh-release@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.0)
 set(CMAKE_CXX_STANDARD 14)
 
 project(OpenCL-SDK
-  VERSION 2022.05.18
+  VERSION 2022.09.23
   LANGUAGES
     C CXX
 )


### PR DESCRIPTION
Fixes #57

I fixed the swallowing of leading zeroes by setting the [CMP0096](https://cmake.org/cmake/help/latest/policy/CMP0096.html) to `NEW`, I also removed manual renaming of the package files and instead give them proper names through CPack. I also added a check to make sure that the project version matches the tag name. Sample release looks like [this](https://github.com/StreamHPC/OpenCL-SDK/releases/tag/untagged-039fd188fc39159408bb) using this CD script, when the project version mismatches the tag name, the script fails like [this](https://github.com/StreamHPC/OpenCL-SDK/actions/runs/3130789378/jobs/5081426187).

Feel free to squash.