### PR TITLE
add pure C and C++ versions of the enumopencl sample

### DIFF
--- a/samples/core/enumopencl/CMakeLists.txt
+++ b/samples/core/enumopencl/CMakeLists.txt
@@ -16,4 +16,4 @@ add_sample(
     TEST
     TARGET enumopencl
     VERSION 120
-    SOURCES main.cpp)
+    SOURCES main.c)

--- a/samples/core/enumopencl/CMakeLists.txt
+++ b/samples/core/enumopencl/CMakeLists.txt
@@ -17,3 +17,10 @@ add_sample(
     TARGET enumopencl
     VERSION 120
     SOURCES main.c)
+
+add_sample(
+    TEST
+    TARGET enumopenclcpp
+    VERSION 120
+    SOURCES main.cpp)
+    

--- a/samples/core/enumopencl/CMakeLists.txt
+++ b/samples/core/enumopencl/CMakeLists.txt
@@ -23,4 +23,3 @@ add_sample(
     TARGET enumopenclcpp
     VERSION 120
     SOURCES main.cpp)
-    

--- a/samples/core/enumopencl/main.c
+++ b/samples/core/enumopencl/main.c
@@ -85,10 +85,6 @@ static cl_int PrintPlatformInfoSummary(cl_platform_id platformId)
     free(platformVendor);
     free(platformVersion);
 
-    platformName = NULL;
-    platformVendor = NULL;
-    platformVersion = NULL;
-
     return errorCode;
 }
 
@@ -194,12 +190,6 @@ static cl_int PrintDeviceInfoSummary(cl_device_id* devices, cl_uint numDevices)
         free(deviceVersion);
         free(deviceProfile);
         free(driverVersion);
-
-        deviceName = NULL;
-        deviceVendor = NULL;
-        deviceVersion = NULL;
-        deviceProfile = NULL;
-        driverVersion = NULL;
     }
 
     return errorCode;

--- a/samples/core/enumopencl/main.c
+++ b/samples/core/enumopencl/main.c
@@ -15,25 +15,18 @@
  */
 
 #include <stdio.h>
-#include <vector>
+#include <stdlib.h>
 
 #include <CL/cl.h>
 
 static cl_int AllocateAndGetPlatformInfoString(cl_platform_id platformId,
                                                cl_platform_info param_name,
-                                               char*& param_value)
+                                               char** pStr)
 {
     cl_int errorCode = CL_SUCCESS;
-    size_t size = 0;
 
-    if (errorCode == CL_SUCCESS)
-    {
-        if (param_value != NULL)
-        {
-            delete[] param_value;
-            param_value = NULL;
-        }
-    }
+    size_t size = 0;
+    char* str = NULL;
 
     if (errorCode == CL_SUCCESS)
     {
@@ -44,8 +37,8 @@ static cl_int AllocateAndGetPlatformInfoString(cl_platform_id platformId,
     {
         if (size != 0)
         {
-            param_value = new char[size];
-            if (param_value == NULL)
+            str = (char*)malloc(size);
+            if (str == NULL)
             {
                 errorCode = CL_OUT_OF_HOST_MEMORY;
             }
@@ -54,14 +47,16 @@ static cl_int AllocateAndGetPlatformInfoString(cl_platform_id platformId,
 
     if (errorCode == CL_SUCCESS)
     {
-        errorCode =
-            clGetPlatformInfo(platformId, param_name, size, param_value, NULL);
+        errorCode = clGetPlatformInfo(platformId, param_name, size, str, NULL);
     }
 
     if (errorCode != CL_SUCCESS)
     {
-        delete[] param_value;
-        param_value = NULL;
+        free(str);
+    }
+    else
+    {
+        *pStr = str;
     }
 
     return errorCode;
@@ -76,19 +71,19 @@ static cl_int PrintPlatformInfoSummary(cl_platform_id platformId)
     char* platformVersion = NULL;
 
     errorCode |= AllocateAndGetPlatformInfoString(platformId, CL_PLATFORM_NAME,
-                                                  platformName);
+                                                  &platformName);
     errorCode |= AllocateAndGetPlatformInfoString(
-        platformId, CL_PLATFORM_VENDOR, platformVendor);
+        platformId, CL_PLATFORM_VENDOR, &platformVendor);
     errorCode |= AllocateAndGetPlatformInfoString(
-        platformId, CL_PLATFORM_VERSION, platformVersion);
+        platformId, CL_PLATFORM_VERSION, &platformVersion);
 
     printf("\tName:           %s\n", platformName);
     printf("\tVendor:         %s\n", platformVendor);
     printf("\tDriver Version: %s\n", platformVersion);
 
-    delete[] platformName;
-    delete[] platformVendor;
-    delete[] platformVersion;
+    free(platformName);
+    free(platformVendor);
+    free(platformVersion);
 
     platformName = NULL;
     platformVendor = NULL;
@@ -99,19 +94,12 @@ static cl_int PrintPlatformInfoSummary(cl_platform_id platformId)
 
 static cl_int AllocateAndGetDeviceInfoString(cl_device_id device,
                                              cl_device_info param_name,
-                                             char*& param_value)
+                                             char** pStr)
 {
     cl_int errorCode = CL_SUCCESS;
-    size_t size = 0;
 
-    if (errorCode == CL_SUCCESS)
-    {
-        if (param_value != NULL)
-        {
-            delete[] param_value;
-            param_value = NULL;
-        }
-    }
+    size_t size = 0;
+    char* str = NULL;
 
     if (errorCode == CL_SUCCESS)
     {
@@ -122,8 +110,8 @@ static cl_int AllocateAndGetDeviceInfoString(cl_device_id device,
     {
         if (size != 0)
         {
-            param_value = new char[size];
-            if (param_value == NULL)
+            str = (char*)malloc(size);
+            if (str == NULL)
             {
                 errorCode = CL_OUT_OF_HOST_MEMORY;
             }
@@ -132,14 +120,16 @@ static cl_int AllocateAndGetDeviceInfoString(cl_device_id device,
 
     if (errorCode == CL_SUCCESS)
     {
-        errorCode =
-            clGetDeviceInfo(device, param_name, size, param_value, NULL);
+        errorCode = clGetDeviceInfo(device, param_name, size, str, NULL);
     }
 
     if (errorCode != CL_SUCCESS)
     {
-        delete[] param_value;
-        param_value = NULL;
+        free(str);
+    }
+    else
+    {
+        *pStr = str;
     }
 
     return errorCode;
@@ -155,7 +145,7 @@ static void PrintDeviceType(const char* label, cl_device_type type)
            (type & CL_DEVICE_TYPE_CUSTOM) ? "CUSTOM " : "");
 }
 
-static cl_int PrintDeviceInfoSummary(cl_device_id* devices, size_t numDevices)
+static cl_int PrintDeviceInfoSummary(cl_device_id* devices, cl_uint numDevices)
 {
     cl_int errorCode = CL_SUCCESS;
 
@@ -166,25 +156,25 @@ static cl_int PrintDeviceInfoSummary(cl_device_id* devices, size_t numDevices)
     char* deviceProfile = NULL;
     char* driverVersion = NULL;
 
-    size_t i = 0;
+    cl_uint i = 0;
     for (i = 0; i < numDevices; i++)
     {
         errorCode |= clGetDeviceInfo(devices[i], CL_DEVICE_TYPE,
                                      sizeof(deviceType), &deviceType, NULL);
         errorCode |= AllocateAndGetDeviceInfoString(devices[i], CL_DEVICE_NAME,
-                                                    deviceName);
+                                                    &deviceName);
         errorCode |= AllocateAndGetDeviceInfoString(
-            devices[i], CL_DEVICE_VENDOR, deviceVendor);
+            devices[i], CL_DEVICE_VENDOR, &deviceVendor);
         errorCode |= AllocateAndGetDeviceInfoString(
-            devices[i], CL_DEVICE_VERSION, deviceVersion);
+            devices[i], CL_DEVICE_VERSION, &deviceVersion);
         errorCode |= AllocateAndGetDeviceInfoString(
-            devices[i], CL_DEVICE_PROFILE, deviceProfile);
+            devices[i], CL_DEVICE_PROFILE, &deviceProfile);
         errorCode |= AllocateAndGetDeviceInfoString(
-            devices[i], CL_DRIVER_VERSION, driverVersion);
+            devices[i], CL_DRIVER_VERSION, &driverVersion);
 
         if (errorCode == CL_SUCCESS)
         {
-            printf("Device[%d]:\n", (int)i);
+            printf("Device[%u]:\n", i);
 
             PrintDeviceType("\tType:           ", deviceType);
 
@@ -196,15 +186,14 @@ static cl_int PrintDeviceInfoSummary(cl_device_id* devices, size_t numDevices)
         }
         else
         {
-            fprintf(stderr, "Error getting device info for device %d.\n",
-                    (int)i);
+            fprintf(stderr, "Error getting device info for device %u.\n", i);
         }
 
-        delete[] deviceName;
-        delete[] deviceVendor;
-        delete[] deviceVersion;
-        delete[] deviceProfile;
-        delete[] driverVersion;
+        free(deviceName);
+        free(deviceVendor);
+        free(deviceVersion);
+        free(deviceProfile);
+        free(driverVersion);
 
         deviceName = NULL;
         deviceVendor = NULL;
@@ -218,56 +207,35 @@ static cl_int PrintDeviceInfoSummary(cl_device_id* devices, size_t numDevices)
 
 int main(int argc, char** argv)
 {
-    bool printUsage = false;
-
-    int i = 0;
-
-    if (argc < 1)
-    {
-        printUsage = true;
-    }
-    else
-    {
-        for (i = 1; i < argc; i++)
-        {
-            {
-                printUsage = true;
-            }
-        }
-    }
-    if (printUsage)
-    {
-        fprintf(stderr,
-                "Usage: enumopencl      [options]\n"
-                "Options:\n");
-
-        return -1;
-    }
-
     cl_uint numPlatforms = 0;
     clGetPlatformIDs(0, NULL, &numPlatforms);
     printf("Enumerated %u platforms.\n\n", numPlatforms);
 
-    std::vector<cl_platform_id> platforms;
-    platforms.resize(numPlatforms);
-    clGetPlatformIDs(numPlatforms, platforms.data(), NULL);
+    cl_platform_id* platforms =
+        (cl_platform_id*)malloc(numPlatforms * sizeof(cl_platform_id));
+    clGetPlatformIDs(numPlatforms, platforms, NULL);
 
-    for (auto& platform : platforms)
+    cl_uint i = 0;
+    for (i = 0; i < numPlatforms; i++)
     {
-        printf("Platform:\n");
-        PrintPlatformInfoSummary(platform);
+        printf("Platform[%u]:\n", i);
+        PrintPlatformInfoSummary(platforms[i]);
 
         cl_uint numDevices = 0;
-        clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, NULL, &numDevices);
+        clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, 0, NULL, &numDevices);
 
-        std::vector<cl_device_id> devices;
-        devices.resize(numDevices);
-        clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, numDevices, devices.data(),
+        cl_device_id* devices =
+            (cl_device_id*)malloc(numDevices * sizeof(cl_device_id));
+        clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, numDevices, devices,
                        NULL);
 
-        PrintDeviceInfoSummary(devices.data(), numDevices);
+        PrintDeviceInfoSummary(devices, numDevices);
         printf("\n");
+
+        free(devices);
     }
+
+    free(platforms);
 
     printf("Done.\n");
 

--- a/samples/core/enumopencl/main.cpp
+++ b/samples/core/enumopencl/main.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020-2023 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <vector>
+
+#include <CL/opencl.hpp>
+
+static cl_int PrintPlatformInfoSummary(cl::Platform platform)
+{
+    printf("\tName:           %s\n",
+           platform.getInfo<CL_PLATFORM_NAME>().c_str());
+    printf("\tVendor:         %s\n",
+           platform.getInfo<CL_PLATFORM_VENDOR>().c_str());
+    printf("\tDriver Version: %s\n",
+           platform.getInfo<CL_PLATFORM_VERSION>().c_str());
+
+    return CL_SUCCESS;
+}
+
+static void PrintDeviceType(const char* label, cl_device_type type)
+{
+    printf("%s%s%s%s%s%s\n", label,
+           (type & CL_DEVICE_TYPE_DEFAULT) ? "DEFAULT " : "",
+           (type & CL_DEVICE_TYPE_CPU) ? "CPU " : "",
+           (type & CL_DEVICE_TYPE_GPU) ? "GPU " : "",
+           (type & CL_DEVICE_TYPE_ACCELERATOR) ? "ACCELERATOR " : "",
+           (type & CL_DEVICE_TYPE_CUSTOM) ? "CUSTOM " : "");
+}
+
+static cl_int PrintDeviceInfoSummary(const std::vector<cl::Device> devices)
+{
+    for (size_t i = 0; i < devices.size(); i++)
+    {
+        printf("Device[%zu]:\n", i);
+
+        cl_device_type deviceType = devices[i].getInfo<CL_DEVICE_TYPE>();
+        PrintDeviceType("\tType:           ", deviceType);
+
+        printf("\tName:           %s\n",
+               devices[i].getInfo<CL_DEVICE_NAME>().c_str());
+        printf("\tVendor:         %s\n",
+               devices[i].getInfo<CL_DEVICE_VENDOR>().c_str());
+        printf("\tDevice Version: %s\n",
+               devices[i].getInfo<CL_DEVICE_VERSION>().c_str());
+        printf("\tDevice Profile: %s\n",
+               devices[i].getInfo<CL_DEVICE_PROFILE>().c_str());
+        printf("\tDriver Version: %s\n",
+               devices[i].getInfo<CL_DRIVER_VERSION>().c_str());
+    }
+
+    return CL_SUCCESS;
+}
+
+int main(int argc, char** argv)
+{
+    std::vector<cl::Platform> platforms;
+    cl::Platform::get(&platforms);
+
+    for (size_t i = 0; i < platforms.size(); i++)
+    {
+        printf("Platform[%zu]:\n", i);
+        PrintPlatformInfoSummary(platforms[i]);
+
+        std::vector<cl::Device> devices;
+        platforms[i].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+
+        PrintDeviceInfoSummary(devices);
+        printf("\n");
+    }
+
+    printf("Done.\n");
+
+    return 0;
+}

--- a/samples/core/enumopencl/main.cpp
+++ b/samples/core/enumopencl/main.cpp
@@ -24,10 +24,10 @@ static cl_int PrintPlatformInfoSummary(cl::Platform platform)
 {
     std::cout << "\tName:           " << platform.getInfo<CL_PLATFORM_NAME>()
               << "\n";
-    std::cout << "\tVendor:         "
-              << platform.getInfo<CL_PLATFORM_VENDOR>() << "\n";
-    std::cout << "\tDriver Version: "
-              << platform.getInfo<CL_PLATFORM_VERSION>() << "\n";
+    std::cout << "\tVendor:         " << platform.getInfo<CL_PLATFORM_VENDOR>()
+              << "\n";
+    std::cout << "\tDriver Version: " << platform.getInfo<CL_PLATFORM_VERSION>()
+              << "\n";
 
     return CL_SUCCESS;
 }

--- a/samples/core/enumopencl/main.cpp
+++ b/samples/core/enumopencl/main.cpp
@@ -14,52 +14,52 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
+#include <iostream>
+#include <string>
 #include <vector>
 
 #include <CL/opencl.hpp>
 
 static cl_int PrintPlatformInfoSummary(cl::Platform platform)
 {
-    printf("\tName:           %s\n",
-           platform.getInfo<CL_PLATFORM_NAME>().c_str());
-    printf("\tVendor:         %s\n",
-           platform.getInfo<CL_PLATFORM_VENDOR>().c_str());
-    printf("\tDriver Version: %s\n",
-           platform.getInfo<CL_PLATFORM_VERSION>().c_str());
+    std::cout << "\tName:           " << platform.getInfo<CL_PLATFORM_NAME>()
+              << "\n";
+    std::cout << "\tVendor:         "
+              << platform.getInfo<CL_PLATFORM_VENDOR>() << "\n";
+    std::cout << "\tDriver Version: "
+              << platform.getInfo<CL_PLATFORM_VERSION>() << "\n";
 
     return CL_SUCCESS;
 }
 
-static void PrintDeviceType(const char* label, cl_device_type type)
+static void PrintDeviceType(const std::string& label, cl_device_type type)
 {
-    printf("%s%s%s%s%s%s\n", label,
-           (type & CL_DEVICE_TYPE_DEFAULT) ? "DEFAULT " : "",
-           (type & CL_DEVICE_TYPE_CPU) ? "CPU " : "",
-           (type & CL_DEVICE_TYPE_GPU) ? "GPU " : "",
-           (type & CL_DEVICE_TYPE_ACCELERATOR) ? "ACCELERATOR " : "",
-           (type & CL_DEVICE_TYPE_CUSTOM) ? "CUSTOM " : "");
+    std::cout << label << ((type & CL_DEVICE_TYPE_DEFAULT) ? "DEFAULT " : "")
+              << ((type & CL_DEVICE_TYPE_CPU) ? "CPU " : "")
+              << ((type & CL_DEVICE_TYPE_GPU) ? "GPU " : "")
+              << ((type & CL_DEVICE_TYPE_ACCELERATOR) ? "ACCELERATOR " : "")
+              << ((type & CL_DEVICE_TYPE_CUSTOM) ? "CUSTOM " : "") << "\n";
 }
 
 static cl_int PrintDeviceInfoSummary(const std::vector<cl::Device> devices)
 {
     for (size_t i = 0; i < devices.size(); i++)
     {
-        printf("Device[%zu]:\n", i);
+        std::cout << "Device[" << i << "]:\n";
 
         cl_device_type deviceType = devices[i].getInfo<CL_DEVICE_TYPE>();
         PrintDeviceType("\tType:           ", deviceType);
 
-        printf("\tName:           %s\n",
-               devices[i].getInfo<CL_DEVICE_NAME>().c_str());
-        printf("\tVendor:         %s\n",
-               devices[i].getInfo<CL_DEVICE_VENDOR>().c_str());
-        printf("\tDevice Version: %s\n",
-               devices[i].getInfo<CL_DEVICE_VERSION>().c_str());
-        printf("\tDevice Profile: %s\n",
-               devices[i].getInfo<CL_DEVICE_PROFILE>().c_str());
-        printf("\tDriver Version: %s\n",
-               devices[i].getInfo<CL_DRIVER_VERSION>().c_str());
+        std::cout << "\tName:           "
+                  << devices[i].getInfo<CL_DEVICE_NAME>() << "\n";
+        std::cout << "\tVendor:         "
+                  << devices[i].getInfo<CL_DEVICE_VENDOR>() << "\n";
+        std::cout << "\tDevice Version: "
+                  << devices[i].getInfo<CL_DEVICE_VERSION>() << "\n";
+        std::cout << "\tDevice Profile: "
+                  << devices[i].getInfo<CL_DEVICE_PROFILE>() << "\n";
+        std::cout << "\tDriver Version: "
+                  << devices[i].getInfo<CL_DRIVER_VERSION>() << "\n";
     }
 
     return CL_SUCCESS;
@@ -69,20 +69,21 @@ int main(int argc, char** argv)
 {
     std::vector<cl::Platform> platforms;
     cl::Platform::get(&platforms);
+    std::cout << "Enumerated " << platforms.size() << " platforms.\n\n";
 
     for (size_t i = 0; i < platforms.size(); i++)
     {
-        printf("Platform[%zu]:\n", i);
+        std::cout << "Platform[" << i << "]:\n";
         PrintPlatformInfoSummary(platforms[i]);
 
         std::vector<cl::Device> devices;
         platforms[i].getDevices(CL_DEVICE_TYPE_ALL, &devices);
 
         PrintDeviceInfoSummary(devices);
-        printf("\n");
+        std::cout << "\n";
     }
 
-    printf("Done.\n");
+    std::cout << "Done.\n";
 
     return 0;
 }


### PR DESCRIPTION
This change switches the existing enumopencl sample to use pure C, compilable with a C compiler (no C++).

It also adds an equivalent C++ sample that makes extensive use of the OpenCL C++ bindings.

The output from both samples is identical.