### PR TITLE
Fix Backwards fopen_s Check

### DIFF
--- a/lib/src/Utils/File.c
+++ b/lib/src/Utils/File.c
@@ -248,7 +248,7 @@ cl_int cl_util_write_binaries(const cl_program program,
 
         // write the binary to the output file
         FILE *f = NULL;
-        if (fopen_s(&f, filename, "wb") != 0)
+        if (fopen_s(&f, filename, "wb") == 0)
         {
             if (fwrite(binaries_ptr[i], sizeof(unsigned char), binaries_size[i],
                        f)


### PR DESCRIPTION
fopen_s, (and the defined macro), return 0 on success, but the if statement is expecting a non-zero value on success.

This causes cl_util_write_binaries to fail, even though it is successfully opening a file.

Can be tested very easily by building and running the "binaries" sample program.
