### PR TITLE
remove unused symlinks

### DIFF
--- a/include/api/CL
+++ b/include/api/CL
@@ -1,1 +1,0 @@
-../../external/OpenCL-Headers/CL

--- a/include/cpp/CL
+++ b/include/cpp/CL
@@ -1,1 +1,0 @@
-../../external/OpenCL-CLHPP/include/CL

--- a/include/utils/CL
+++ b/include/utils/CL
@@ -1,1 +1,0 @@
-../../utils/include/CL


### PR DESCRIPTION
These symlinks cause issues when the SDK is deployed on some systems.

Fixes #82