### PR TITLE
Fix whereami dependency target

### DIFF
--- a/cmake/Dependencies/whereami/whereami.cmake
+++ b/cmake/Dependencies/whereami/whereami.cmake
@@ -8,8 +8,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(whereami-external)
 add_library(whereami IMPORTED INTERFACE)
 target_include_directories(whereami
-  INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/_deps/whereami-external-src/src"
+    INTERFACE "${whereami-external_SOURCE_DIR}/src"
 )
 target_sources(whereami
-  INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/_deps/whereami-external-src/src/whereami.c"
+  INTERFACE "${whereami-external_SOURCE_DIR}/src/whereami.c"
 )


### PR DESCRIPTION
When adding OpenCL-SDK  via CPMAddPackage (cmake 3.22.1) as such:

```
CPMAddPackage(
  NAME OpenCL_SDK
  GIT_TAG v2023.12.14
  GITHUB_REPOSITORY "KhronosGroup/OpenCL-SDK"
  OPTIONS
    "BUILD_TESTING OFF"
    "BUILD_TESTS OFF"
    "BUILD_DOCS OFF"
    "OPENCL_SDK_BUILD_SAMPLES OFF"
    "OPENCL_SDK_TEST_SAMPLES OFF"
    "OPENCL_SDK_BUILD_OPENGL_SAMPLES OFF"
)
```

the following is issued:

```
CMake Error at build/_deps/opencl_sdk-src/lib/CMakeLists.txt:23 (add_libr
ary):
  Cannot find source file:

    ##############/proj/build/_deps/opencl_sdk-build/_d
eps/whereami-external-src/src/whereami.c

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
 .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .is
pc


CMake Error in build/_deps/opencl_sdk-src/lib/CMakeLists.txt:
  Imported target "whereami" includes non-existent path

    "##############/proj/build/_deps/opencl_sdk-build/_
deps/whereami-external-src/src"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.



CMake Error in build/_deps/opencl_sdk-src/lib/CMakeLists.txt:
  Imported target "whereami" includes non-existent path

    "##############/proj/build/_deps/opencl_sdk-build/_
deps/whereami-external-src/src"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

as `whereami/whereami.cmake` depends on `CMAKE_CURRENT_BINARY_DIR` for the include/source paths.
This change should fix that without side-effects.