### PR TITLE
whereami: Use SOURCE_DIR variable

### DIFF
--- a/cmake/Dependencies/whereami/whereami.cmake
+++ b/cmake/Dependencies/whereami/whereami.cmake
@@ -8,8 +8,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(whereami-external)
 add_library(whereami IMPORTED INTERFACE)
 target_include_directories(whereami
-  INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/_deps/whereami-external-src/src"
+  INTERFACE "${whereami-external_SOURCE_DIR}/src"
 )
 target_sources(whereami
-  INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/_deps/whereami-external-src/src/whereami.c"
+  INTERFACE "${whereami-external_SOURCE_DIR}/src/whereami.c"
 )


### PR DESCRIPTION
Replace the hard-coded source dir location with an public source dir output variable provided by `FetchContent`. This decouples the SDK from the current implementation details of `FetchContent`, and it allows packagers or disconnected builds to inject a pre-fetched location via input variable `FETCHCONTENT_SOURCE_DIR_WHEREAMI-EXTERNAL`.