### PR TITLE
Fix install rule for utility libraries

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(UTIL_LIB_NAME IN ITEMS Utils UtilsCpp)
   )
   target_link_libraries(${UTIL_LIB_TARGET}
     PRIVATE
-      whereami
+      $<BUILD_INTERFACE:whereami>
     PUBLIC
       ${UTIL_LIB_DEPS}
       OpenCL::OpenCL

--- a/test/cmake/pkgconfig/useutil/CMakeLists.txt
+++ b/test/cmake/pkgconfig/useutil/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.16)
 project(PkgConfigTest-UseUtil)
 
 include(CTest)
-include("${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/Dependencies/whereami/whereami.cmake")
 
 find_package(OpenCL
   REQUIRED
@@ -28,7 +27,6 @@ target_link_libraries(${PROJECT_NAME}_cpp
     OpenCL::HeadersCpp
     OpenCL::Headers
     OpenCL::OpenCL
-    whereami
 )
 
 target_compile_definitions(${PROJECT_NAME}_cpp
@@ -53,7 +51,6 @@ target_link_libraries(${PROJECT_NAME}_c
     OpenCL::Utils
     OpenCL::Headers
     OpenCL::OpenCL
-    whereami
 )
 
 target_compile_definitions(${PROJECT_NAME}_c


### PR DESCRIPTION
The utility libraries accidentally had whereami linkage in their install targets which imposed an unnecessary requirement on users of the utility library. The tests worked around this issue instead of fixing it.