### PR TITLE
Sfml ver fix

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -133,6 +133,7 @@ jobs:
       CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
       CPACK_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cpack
       CTEST_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/ctest
+      VCPKG_INSTALLATION_ROOT: /opt/Microsoft/vcpkg
       DEB_INSTALLATION_PATH: /usr
       CC: ${{matrix.COMPILER.C_NAME}}-${{matrix.COMPILER.VER}}
       CXX:  ${{matrix.COMPILER.CXX_NAME}}-${{matrix.COMPILER.VER}}
@@ -167,16 +168,10 @@ jobs:
     - name: Install dependencies (vcpkg)
       if: matrix.DEPS == 'vcpkg' && steps.vcpkg-install.outputs.cache-hit != 'true'
       run: |
-        cd /opt/Microsoft/vcpkg
+        cd $VCPKG_INSTALLATION_ROOT
         git pull
         ./bootstrap-vcpkg.sh
-        ./vcpkg --triplet=$VCPKG_TRIPLET install tclap stb
-        # It is not possible to cross-compile the OpenGL samples on Ubuntu
-        # because system dev dependencies are not available for i386
-        if [[ "${{ matrix.BIN }}" == "64" ]]; then
-          ./vcpkg --triplet=$VCPKG_TRIPLET install sfml glm glew;
-        fi
-
+  
     - name: Set up compiler flags
       run: |
         # Excluding missing-field-initializers error because it comes from the Std dependency
@@ -250,7 +245,7 @@ jobs:
       run: $CMAKE_EXE
         -G "${{matrix.CONF.GEN}}"
         `if [[ "${{matrix.CONF.GEN}}" == "Unix Makefiles" ]]; then echo "-D CMAKE_BUILD_TYPE=${{matrix.CONF.CONFIG}}"; fi`
-        `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D CMAKE_TOOLCHAIN_FILE=/opt/Microsoft/vcpkg/scripts/buildsystems/vcpkg.cmake"; fi;`
+        `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"; fi;`
         `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D VCPKG_TARGET_TRIPLET=$VCPKG_TRIPLET"; fi;`
         -D BUILD_DOCS=ON
         -D BUILD_TESTING=ON
@@ -417,6 +412,12 @@ jobs:
         Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
         Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath ${env:NINJA_ROOT}\
         Remove-Item ~\Downloads\*
+
+    - name: Update Vcpkg
+      if: matrix.DEPS == 'vcpkg'
+      run: |
+        git -C ${env:VCPKG_INSTALLATION_ROOT} pull
+        & ${env:VCPKG_INSTALLATION_ROOT}\bootstrap-vcpkg.bat
 
     - name: Install OpenCL runtime
       if: matrix.BIN != 'x86'
@@ -666,12 +667,12 @@ jobs:
       if: matrix.DEPS == 'system'
       run: brew install tclap glm glew sfml mesa-glu
 
-    - name: Install dependencies (vcpkg)
+    - name: Install Vcpkg
       if: matrix.DEPS == 'vcpkg'
       run: |
         git clone https://github.com/Microsoft/vcpkg.git vcpkg
         ./vcpkg/bootstrap-vcpkg.sh
-        ./vcpkg/vcpkg install tclap glm glew sfml stb
+        echo "VCPKG_INSTALLATION_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
 
     - name: Set up compiler flags
       run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -156,30 +156,27 @@ jobs:
     - name: Install dependencies (system)
       if: matrix.DEPS == 'system'
       run: apt-get update -qq && apt-get install -y libfreetype-dev libsfml-dev libglm-dev libglew-dev libtclap-dev libstb-dev
-  
-    - name: Cache dependencies (vcpkg)
-      if: matrix.DEPS == 'vcpkg'
-      id: vcpkg-install
-      uses: actions/cache@v4
-      with:
-        path: /opt/Microsoft/vcpkg
-        key: vcpkg-linux-${{matrix.BIN}}
 
     - name: Install dependencies (vcpkg)
-      if: matrix.DEPS == 'vcpkg' && steps.vcpkg-install.outputs.cache-hit != 'true'
+      if: matrix.DEPS == 'vcpkg'
       run: |
         cd $VCPKG_INSTALLATION_ROOT
         git pull
         ./bootstrap-vcpkg.sh
-  
+        if [[ "${{matrix.BIN}}" == "32" ]]; then
+          dpkg --add-architecture i386
+          apt-get update
+          apt-get install -y autoconf libtool pkg-config libxmu-dev:i386 libxi-dev:i386 libgl-dev:i386 libglu1-mesa-dev:i386 libudev-dev:i386 libx11-dev:i386 libxrandr-dev:i386 libxcursor-dev:i386
+        fi;
+
     - name: Set up compiler flags
       run: |
         # Excluding missing-field-initializers error because it comes from the Std dependency
         # Excluding maybe-uninitialized error because cannot workaround the compiler issuing this error
         # Not using -pedantic: error: ISO C forbids braced-groups within expressions
-        echo "CFLAGS=-Wall -Wextra -Werror -m${{matrix.BIN}} -Wno-missing-field-initializers ${{ matrix.COMPILER.EXCLUSIVE_C_FLAGS }}" >> $GITHUB_ENV;
+        echo "CMAKE_CFLAGS=-Wall -Wextra -Werror -m${{matrix.BIN}} -Wno-missing-field-initializers ${{ matrix.COMPILER.EXCLUSIVE_C_FLAGS }}" >> $GITHUB_ENV;
         # Excluding missing-field-initializers error because it comes from the Std dependency
-        echo "CXXFLAGS=-Wall -Wextra -pedantic -Werror -m${{matrix.BIN}} -Wno-missing-field-initializers ${{ matrix.COMPILER.EXCLUSIVE_CXX_FLAGS }}" >> $GITHUB_ENV;
+        echo "CMAKE_CXXFLAGS=-Wall -Wextra -pedantic -Werror -m${{matrix.BIN}} -Wno-missing-field-initializers ${{ matrix.COMPILER.EXCLUSIVE_CXX_FLAGS }}" >> $GITHUB_ENV;
 
     - name: Checkout OpenCL-SDK
       uses: actions/checkout@v4
@@ -245,6 +242,7 @@ jobs:
       run: $CMAKE_EXE
         -G "${{matrix.CONF.GEN}}"
         `if [[ "${{matrix.CONF.GEN}}" == "Unix Makefiles" ]]; then echo "-D CMAKE_BUILD_TYPE=${{matrix.CONF.CONFIG}}"; fi`
+        `if [[ "${{matrix.CONF.GEN}}" == "Unix Makefiles" ]]; then echo "-D CMAKE_MAKE_PROGRAM=/usr/bin/make"; else echo "-D CMAKE_MAKE_PROGRAM=/usr/bin/ninja"; fi`
         `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"; fi;`
         `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D VCPKG_TARGET_TRIPLET=$VCPKG_TRIPLET"; fi;`
         -D BUILD_DOCS=ON
@@ -255,6 +253,8 @@ jobs:
         -D OPENCL_ICD_LOADER_BUILD_TESTING=ON
         -D CMAKE_C_STANDARD=${{matrix.STD.C}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}}
+        -D CMAKE_C_FLAGS="${CMAKE_CFLAGS}"
+        -D CMAKE_CXX_FLAGS="${CMAKE_CXXFLAGS}"
         -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
         -D CPACK_PACKAGING_INSTALL_PREFIX=$DEB_INSTALLATION_PATH
         -S $GITHUB_WORKSPACE
@@ -281,6 +281,7 @@ jobs:
         fi;
 
     - name: Package DEB
+      if: matrix.BIN != 32
       run: $CPACK_EXE
         --config "$GITHUB_WORKSPACE/build/CPackConfig.cmake"
         -G DEB
@@ -288,6 +289,7 @@ jobs:
         -B "$GITHUB_WORKSPACE/package-deb"
 
     - name: Consume (DEB)
+      if: matrix.BIN != 32
       run: dpkg -i $GITHUB_WORKSPACE/package-deb/*.deb &&
         $CMAKE_EXE
         -G "${{matrix.CONF.GEN}}"
@@ -316,9 +318,11 @@ jobs:
         fi
 
     - name: Run clinfo (DEB)
+      if: matrix.BIN != 32
       run: clinfo
 
     - name: Uninstall (DEB)
+      if: matrix.BIN != 32
       run: apt-get remove -y "khronos-opencl-loader*" opencl-c-headers opencl-clhpp-headers opencl-sdk clinfo
 
     - name: Test install
@@ -335,6 +339,8 @@ jobs:
         -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install
         -D CMAKE_C_STANDARD=${{matrix.STD.C}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}}
+        -D CMAKE_C_FLAGS="${CMAKE_CFLAGS}"
+        -D CMAKE_CXX_FLAGS="${CMAKE_CXXFLAGS}"
         -S $GITHUB_WORKSPACE/test/cmake/pkgconfig/useutil
         -B $GITHUB_WORKSPACE/build_install &&
         if [[ "${{matrix.CONF.GEN}}" == "Unix Makefiles" ]];
@@ -437,23 +443,10 @@ jobs:
         New-Item -Type File HKLM:\SOFTWARE\Khronos\OpenCL\Vendors | Out-Null; `
         Set-ItemProperty -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors -Name ${env:IMAGE_INTEL_PREFIX}\oclcpuexp\intelocl64.dll -Type DWord -Value 0;
 
-    - name: Cache dependencies (vcpkg)
-      if: matrix.DEPS == 'vcpkg'
-      id: vcpkg-install
-      uses: actions/cache@v4
-      with:
-        path: |
-          C:\vcpkg
-        key: x64-windows-sfml-tclap-glm-glew-stb
-
-    - name: Install dependencies (vcpkg)
-      if: matrix.DEPS == 'vcpkg' && steps.vcpkg-install.outputs.cache-hit != 'true'
-      run: C:\vcpkg\vcpkg.exe --triplet=x64-windows install sfml tclap glm glew stb
-
     - name: Set up compiler flags
       run: |
-        echo "CFLAGS=/W4 /WX" >> $GITHUB_ENV
-        echo "CXXFLAGS=/W4 /WX" >> $GITHUB_ENV
+        Write-Output "CMAKE_CFLAGS=/W4" | Out-File $env:GITHUB_ENV -Append
+        Write-Output "CMAKE_CXXFLAGS=/W4 /EHsc" | Out-File $env:GITHUB_ENV -Append
 
     - name: Checkout OpenCL-SDK
       uses: actions/checkout@v4
@@ -480,6 +473,8 @@ jobs:
           -D OPENCL_SDK_BUILD_SAMPLES=ON `
           -D CMAKE_C_STANDARD=${{matrix.STD.C}} `
           -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}} `
+          -D CMAKE_C_FLAGS="${env:CMAKE_CFLAGS}" `
+          -D CMAKE_CXX_FLAGS="${env:CMAKE_CXXFLAGS}" `
           -D CMAKE_INSTALL_PREFIX=${env:GITHUB_WORKSPACE}\install `
           -S ${env:GITHUB_WORKSPACE} `
           -B ${env:GITHUB_WORKSPACE}\build
@@ -507,6 +502,8 @@ jobs:
           -D OPENCL_SDK_BUILD_SAMPLES=ON `
           -D CMAKE_C_STANDARD=${{matrix.STD.C}} `
           -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}} `
+          -D CMAKE_C_FLAGS="${env:CMAKE_CFLAGS}" `
+          -D CMAKE_CXX_FLAGS="${env:CMAKE_CXXFLAGS}" `
           -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
           -D CMAKE_INSTALL_PREFIX=${env:GITHUB_WORKSPACE}\install `
           -S ${env:GITHUB_WORKSPACE} `
@@ -681,23 +678,26 @@ jobs:
         #  * -Wno-missing-field-initializers
         #  * -Wno-conditional-uninitialized
         # have been added because of Std compilation errors
-        echo "CFLAGS=-Wall -Wextra -Werror -Wno-missing-field-initializers -Wno-conditional-uninitialized" >> $GITHUB_ENV;
+        echo "CMAKE_CFLAGS=-Wall -Wextra -Werror -Wno-missing-field-initializers -Wno-conditional-uninitialized" >> $GITHUB_ENV;
         # The flags
         #  * -Wno-deprecated-declarations
         #  * -Wno-missing-field-initializers
         # have been added because of Std compilation errors
-        echo "CXXFLAGS=-Wall -Wextra -pedantic -Wno-format -Werror -Wno-missing-field-initializers -Wno-deprecated-declarations" >> $GITHUB_ENV;
+        echo "CMAKE_CXXFLAGS=-Wall -Wextra -pedantic -Wno-format -Werror -Wno-missing-field-initializers -Wno-deprecated-declarations" >> $GITHUB_ENV;
 
     - name: Configure
       run: cmake
         -G "${{matrix.GEN}}"
         `if [[ "${{matrix.DEPS}}" == "vcpkg" ]]; then echo "-D CMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake"; fi`
+        `if [[ "${{matrix.GEN}}" == "Ninja Multi-Config" ]]; then echo "-D CMAKE_MAKE_PROGRAM=ninja"; fi`
         -D BUILD_DOCS=ON
         -D BUILD_TESTING=ON
         -D BUILD_EXAMPLES=ON
         -D OPENCL_SDK_BUILD_SAMPLES=ON
         -D CMAKE_C_STANDARD=${{matrix.STD.C}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}}
+        -D CMAKE_C_FLAGS="${CMAKE_CFLAGS}"
+        -D CMAKE_CXX_FLAGS="${CMAKE_CXXFLAGS}"
         -D CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
         -D CMAKE_OSX_ARCHITECTURES=arm64
         -S $GITHUB_WORKSPACE

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,7 +2,12 @@ name: Presubmit
 
 on:
   pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - 'LICENSES/**'
+      - '**.md'
   push:
+    branches: [main]
     paths-ignore:
       - 'LICENSE'
       - 'LICENSES/**'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -409,21 +409,9 @@ jobs:
       IMAGE_INTEL_PREFIX: C:\Tools\Intel
 
     steps:
-    - name: Cache Ninja install
-      if: matrix.GEN == 'Ninja Multi-Config'
-      id: ninja-install
-      uses: actions/cache@v4
-      with:
-        path: |
-          C:\Tools\Ninja
-        key: ${{runner.os}}-ninja-${{env.NINJA_URL}}
 
-    - name: Install Ninja
-      if: matrix.GEN == 'Ninja Multi-Config' && steps.ninja-install.outputs.cache-hit != 'true'
-      run: |
-        Invoke-WebRequest ${env:NINJA_URL} -OutFile ~\Downloads\ninja-win.zip
-        Expand-Archive ~\Downloads\ninja-win.zip -DestinationPath ${env:NINJA_ROOT}\
-        Remove-Item ~\Downloads\*
+    - name: Install CMake & Ninja
+      uses: lukka/get-cmake@v3.26.4
 
     - name: Update Vcpkg
       if: matrix.DEPS == 'vcpkg'
@@ -669,6 +657,9 @@ jobs:
     - name: Install dependencies (Homebrew)
       if: matrix.DEPS == 'system'
       run: brew install tclap glm glew sfml mesa-glu
+
+    - name: Install CMake & Ninja
+      uses: lukka/get-cmake@v3.26.4
 
     - name: Install Vcpkg
       if: matrix.DEPS == 'vcpkg'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -408,7 +408,6 @@ jobs:
             CXX: 14
     env:
       NINJA_URL: https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
-      NINJA_ROOT: C:\Tools\Ninja
       VS_ROOT: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise'
       UseMultiToolTask: true # Better parallel MSBuild execution
       EnforceProcessCountAcrossBuilds: 'true' # -=-
@@ -500,7 +499,7 @@ jobs:
         & cmake `
           $TOOLCHAIN_ARG `
           -G "${{matrix.GEN}}" `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_MAKE_PROGRAM="ninja.exe" `
           -D BUILD_DOCS=ON `
           -D BUILD_TESTING=ON `
           -D OPENCL_SDK_BUILD_SAMPLES=ON `
@@ -596,7 +595,7 @@ jobs:
         Enter-VsDevShell -VsInstallPath ${env:VS_ROOT} -SkipAutomaticLocation -DevCmdArguments "-host_arch=x64 -arch=${{matrix.BIN}} -vcvars_ver=${VER}"
         & cmake `
           -G '${{matrix.GEN}}' `
-          -D CMAKE_MAKE_PROGRAM="${env:NINJA_ROOT}\ninja.exe" `
+          -D CMAKE_MAKE_PROGRAM="ninja.exe" `
           -D CMAKE_EXE_LINKER_FLAGS=/INCREMENTAL `
           -D CMAKE_PREFIX_PATH="${env:GITHUB_WORKSPACE}\external\OpenCL-Headers\install;${env:GITHUB_WORKSPACE}\install" `
           -D CMAKE_C_STANDARD=${{matrix.STD.C}} `

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,6 +1,12 @@
 name: Presubmit
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'LICENSE'
+      - 'LICENSES/**'
+      - '**.md'
 
 jobs:
   format:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -58,7 +58,10 @@ jobs:
           CXX_NAME: clang++
           VER: 16
           EXCLUSIVE_C_FLAGS: ""
-        DEPS: [system, vcpkg, fetch]
+        DEPS: [
+          system,
+          #vcpkg,
+          fetch]
         BIN: [64]
         STD:
         - C: 11 # Utils C library uses C11 functions (e.g. timespec_get)
@@ -109,36 +112,36 @@ jobs:
             GEN: Unix Makefiles
             CONFIG: Release
           IMAGE: khronosgroup/docker-images:opencl-sdk-intelcpu-ubuntu-20.04.20230717
-        - CMAKE: system
-          COMPILER:
-            C_NAME: gcc
-            CXX_NAME: g++
-            VER: 9
-            EXCLUSIVE_C_FLAGS: ""
-          DEPS: vcpkg
-          BIN: 32
-          STD:
-            C: 11
-            CXX: 14
-          CONF:
-            GEN: Unix Makefiles
-            CONFIG: Debug
-          IMAGE: khronosgroup/docker-images:opencl-sdk-intelcpu-ubuntu-20.04.20230717
-        - CMAKE: system
-          COMPILER:
-            C_NAME: gcc
-            CXX_NAME: g++
-            VER: 9
-            EXCLUSIVE_C_FLAGS: ""
-          DEPS: vcpkg
-          BIN: 32
-          STD:
-            C: 11
-            CXX: 14
-          CONF:
-            GEN: Unix Makefiles
-            CONFIG: Release
-          IMAGE: khronosgroup/docker-images:opencl-sdk-intelcpu-ubuntu-20.04.20230717
+        #- CMAKE: system
+        #  COMPILER:
+        #    C_NAME: gcc
+        #    CXX_NAME: g++
+        #    VER: 9
+        #    EXCLUSIVE_C_FLAGS: ""
+        #  DEPS: vcpkg
+        #  BIN: 32
+        #  STD:
+        #    C: 11
+        #    CXX: 14
+        #  CONF:
+        #    GEN: Unix Makefiles
+        #    CONFIG: Debug
+        #  IMAGE: khronosgroup/docker-images:opencl-sdk-intelcpu-ubuntu-20.04.20230717
+        #- CMAKE: system
+        #  COMPILER:
+        #    C_NAME: gcc
+        #    CXX_NAME: g++
+        #    VER: 9
+        #    EXCLUSIVE_C_FLAGS: ""
+        #  DEPS: vcpkg
+        #  BIN: 32
+        #  STD:
+        #    C: 11
+        #    CXX: 14
+        #  CONF:
+        #    GEN: Unix Makefiles
+        #    CONFIG: Release
+        #  IMAGE: khronosgroup/docker-images:opencl-sdk-intelcpu-ubuntu-20.04.20230717
     container: ${{matrix.IMAGE}}
     env:
       CMAKE_EXE: /opt/Kitware/CMake/${{ matrix.CMAKE }}/bin/cmake
@@ -383,7 +386,9 @@ jobs:
       matrix:
         VER: [v142, v143, clangcl]
         GEN: [Visual Studio 17 2022, Ninja Multi-Config]
-        DEPS: [vcpkg, fetch]
+        DEPS: [
+          #vcpkg,
+          fetch]
         BIN: [x64]
         STD:
         - C: 11
@@ -630,10 +635,11 @@ jobs:
         GEN:
         - Xcode
         - Ninja Multi-Config
-        DEPS:
-        - system
-        - vcpkg
-        - fetch
+        DEPS: [
+          system,
+          #vcpkg
+          fetch
+        ]
         STD:
         - C: 11
           CXX: 14

--- a/README.md
+++ b/README.md
@@ -48,21 +48,16 @@ If CMake is not provided by your build system or OS package manager, please cons
        git submodule init
        git submodule update
 
-1. Install dependencies:
-
-       vcpkg --triplet x64-windows install sfml tclap glm
-
 1. Build and install SDK with samples and no downstream unit tests:
 
-       cmake -A x64 `
-             -D BUILD_TESTING=OFF `
-             -D BUILD_DOCS=OFF `
-             -D BUILD_EXAMPLES=OFF `
-             -D BUILD_TESTS=OFF `
-             -D OPENCL_SDK_BUILD_SAMPLES=ON `
-             -D OPENCL_SDK_TEST_SAMPLES=OFF `
-             -D CMAKE_TOOLCHAIN_FILE=/vcpkg/install/root/scripts/buildsystems/vcpkg.cmake `
-             -D VCPKG_TARGET_TRIPLET=x64-windows `
+       cmake -D BUILD_TESTING=OFF \
+             -D BUILD_DOCS=OFF \
+             -D BUILD_EXAMPLES=OFF \
+             -D BUILD_TESTS=OFF \
+             -D OPENCL_SDK_BUILD_SAMPLES=ON \
+             -D OPENCL_SDK_TEST_SAMPLES=OFF \
+             -D CMAKE_TOOLCHAIN_FILE=/vcpkg/install/root/scripts/buildsystems/vcpkg.cmake \
+             -D CMAKE_BUILD_TYPE=Release \
              -B ./OpenCL-SDK/build -S ./OpenCL-SDK
        cmake --build ./OpenCL-SDK/build --target install
 

--- a/cmake/Dependencies/SFML/SFML.cmake
+++ b/cmake/Dependencies/SFML/SFML.cmake
@@ -24,7 +24,7 @@ if(NOT (SFML_FOUND OR TARGET SFML::Graphics))
   FetchContent_Declare(
     sfml-external
     GIT_REPOSITORY      https://github.com/SFML/SFML.git
-    GIT_TAG             2.6.1 # 69ea0cd863aed1d4092b970b676924a716ff718b
+    GIT_TAG             2.6.2 # 65383d2b3948f805af55c9f8a4587ac72ec5981d1
     PATCH_COMMAND       ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${CMAKE_CURRENT_BINARY_DIR}/_deps/sfml-external-src/src/SFML/Graphics/CMakeLists.txt"
   )
   FetchContent_MakeAvailable(sfml-external)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+	"name": "opencl",
+	"builtin-baseline": "21816e0df975ab3ba13ab75263c4deeb080ef681",
+	"dependencies": [
+		{
+			"name": "sfml",
+			"version>=": "2.0"
+		},
+		"tclap",
+		"glm",
+		"glew",
+		"stb"
+	],
+	"overrides": [
+		{
+			"name": "sfml",
+			"version": "2.6.2"
+		}
+	]
+}


### PR DESCRIPTION
All Vcpkg CI elements started failing recently, which is fixed by this PR. The core of the issue was that SFML, a dependency of the graphical samples built in CI have released a new major version, SFML3, which is incompatible with SFML2. It has slightly different CMake-side support, as well as slightly different interfaces. The fix involves pinning the version of SFML fetched from CMake, which can only be done via a manifest file; it's not possible via the CLI.

## Notes for the reviewer

- There are two commits in this PR. The first strictly deals with introducing the manifest file for Vcpkg and updating autofetching to the latest 2.x version available.
  - Caching Vcpkg installs got removed for the time being. Partly because it needs to be done differently (given how it's not a separate CLI invocation now, but part of the configuration process), but also because the keys used to identify the caches needed a facelift and it requires extra testing to make sure it works inside the configuration process to begin with. Vcpkg [has its own caching](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching) mechanism too, so it may even prove to be unnecessary, or it can be reintroduced later with a proper key holding tool version strings.
  - Windows builds were using the system Vcpkg install un-updated, so were potentially installing different versions of deps than the Linux and MacOS builds.
- The second commit deals with a number of issues (skeletons in the closet). Solving the Vcpkg issue uncovered some unintended shortcomings.
  - Compiler flags were given to CMake via environmental variables, which unintentionally propagate into Vcpkg builds. Naturally, not all ports build warning-free with high warning levels.
  - Giving compiler flags was also not done properly, so 32-bit builds were actually 64-bit. Once fixed, DEB packaging turned out to be incompatible with 64-bit systems (like in CI). Proper multi-arch packaging requires some extra care apparently. (They should work fine on 32-bit only systems.)
  - 32-bit builds seem to require explicitly specifying the make program in order for Vcpkg to pick them up, therefore these were made explicit.
  - Getting proper 32-bit builds uncovered we need to install the 32-bit versions of the libs SFML depends on and needs from the system. (The CI image has the native 64-bit version installed)