### PR TITLE
updates README build instructions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,6 +7,7 @@ on:
       - 'LICENSES/**'
       - '**.md'
   push:
+    branches: [main]
     paths-ignore:
       - 'LICENSE'
       - 'LICENSES/**'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -896,6 +896,7 @@ jobs:
       run:
         shell: bash
     runs-on: ${{ matrix.os }}
+    needs: format
     steps:
     - name: Checkout OpenCL-SDK
       uses: actions/checkout@v4
@@ -906,7 +907,6 @@ jobs:
     - name: Generate Build Files
       run: cmake
         -DCMAKE_BUILD_TYPE=Release
-        `if [[ "${{matrix.os}}" == "macos-latest" ]]; then echo "-DOPENCL_SDK_BUILD_VULKAN_SAMPLES=OFF"; fi;`
         -S $GITHUB_WORKSPACE
         -B $GITHUB_WORKSPACE/build
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,7 +7,6 @@ on:
       - 'LICENSES/**'
       - '**.md'
   push:
-    branches: [main]
     paths-ignore:
       - 'LICENSE'
       - 'LICENSES/**'
@@ -887,3 +886,33 @@ jobs:
 
     - name: Build
       run: cmake --build $GITHUB_WORKSPACE/build --parallel `nproc`
+
+  simple-readme-build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    name: Simple README Build on ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout OpenCL-SDK
+      uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
+          submodules: recursive
+
+    - name: Generate Build Files
+      run: cmake
+        -DCMAKE_BUILD_TYPE=Release
+        `if [[ "${{matrix.os}}" == "macos-latest" ]]; then echo "-DOPENCL_SDK_BUILD_VULKAN_SAMPLES=OFF"; fi;`
+        -S $GITHUB_WORKSPACE
+        -B $GITHUB_WORKSPACE/build
+
+    - name: Build
+      run: cmake
+        --build $GITHUB_WORKSPACE/build
+        --target install
+        --config Release
+        --parallel `nproc`

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -274,6 +274,7 @@ jobs:
         -D BUILD_EXAMPLES=ON
         -D OPENCL_SDK_BUILD_SAMPLES=ON
         -D OPENCL_SDK_BUILD_OPENGL_SAMPLES=ON
+        -D OPENCL_SDK_BUILD_VULKAN_SAMPLES=ON
         `if [[ "${{matrix.BIN}}" == "32" ]]; then echo "-D OPENCL_SDK_BUILD_OPENGL_SAMPLES=OFF"; fi;`
         -D OPENCL_ICD_LOADER_BUILD_TESTING=ON
         -D CMAKE_C_STANDARD=${{matrix.STD.C}}
@@ -500,6 +501,7 @@ jobs:
           -D BUILD_TESTING=ON `
           -D OPENCL_SDK_BUILD_SAMPLES=ON `
           -D OPENCL_SDK_BUILD_OPENGL_SAMPLES=ON `
+          -D OPENCL_SDK_BUILD_VULKAN_SAMPLES=ON `
           -D CMAKE_C_STANDARD=${{matrix.STD.C}} `
           -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}} `
           -D CMAKE_C_FLAGS="${env:CMAKE_CFLAGS}" `
@@ -532,6 +534,7 @@ jobs:
           -D BUILD_TESTING=ON `
           -D OPENCL_SDK_BUILD_SAMPLES=ON `
           -D OPENCL_SDK_BUILD_OPENGL_SAMPLES=ON `
+          -D OPENCL_SDK_BUILD_VULKAN_SAMPLES=ON `
           -D CMAKE_C_STANDARD=${{matrix.STD.C}} `
           -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}} `
           -D CMAKE_C_FLAGS="${env:CMAKE_CFLAGS}" `
@@ -739,6 +742,7 @@ jobs:
         -D BUILD_EXAMPLES=ON
         -D OPENCL_SDK_BUILD_SAMPLES=ON
         -D OPENCL_SDK_BUILD_OPENGL_SAMPLES=ON
+        -D OPENCL_SDK_BUILD_VULKAN_SAMPLES=ON
         -D CMAKE_C_STANDARD=${{matrix.STD.C}}
         -D CMAKE_CXX_STANDARD=${{matrix.STD.CXX}}
         -D CMAKE_C_FLAGS="${CMAKE_CFLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project(OpenCL-SDK
 include(CMakeDependentOption)
 option(OPENCL_SDK_BUILD_UTILITY_LIBRARIES "Build utility libraries" ON)
 cmake_dependent_option(OPENCL_SDK_BUILD_SAMPLES "Build sample code" ON OPENCL_SDK_BUILD_UTILITY_LIBRARIES OFF)
-cmake_dependent_option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF)
-cmake_dependent_option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" OFF)
+option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF)
+option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" OFF)
 cmake_dependent_option(OPENCL_SDK_TEST_SAMPLES "Add CTest to samples (where applicable)" ON OPENCL_SDK_BUILD_SAMPLES OFF)
 
 option(OPENCL_SDK_BUILD_CLINFO "Build clinfo utility" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project(OpenCL-SDK
 include(CMakeDependentOption)
 option(OPENCL_SDK_BUILD_UTILITY_LIBRARIES "Build utility libraries" ON)
 cmake_dependent_option(OPENCL_SDK_BUILD_SAMPLES "Build sample code" ON OPENCL_SDK_BUILD_UTILITY_LIBRARIES OFF)
-option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF)
-option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" OFF)
+cmake_dependent_option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF OPENCL_SDK_BUILD_SAMPLES OFF)
+cmake_dependent_option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" OFF OPENCL_SDK_BUILD_SAMPLES OFF)
 cmake_dependent_option(OPENCL_SDK_TEST_SAMPLES "Add CTest to samples (where applicable)" ON OPENCL_SDK_BUILD_SAMPLES OFF)
 
 option(OPENCL_SDK_BUILD_CLINFO "Build clinfo utility" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project(OpenCL-SDK
 include(CMakeDependentOption)
 option(OPENCL_SDK_BUILD_UTILITY_LIBRARIES "Build utility libraries" ON)
 cmake_dependent_option(OPENCL_SDK_BUILD_SAMPLES "Build sample code" ON OPENCL_SDK_BUILD_UTILITY_LIBRARIES OFF)
-cmake_dependent_option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF OPENCL_SDK_BUILD_SAMPLES OFF)
-cmake_dependent_option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" ON OPENCL_SDK_BUILD_SAMPLES OFF)
+cmake_dependent_option(OPENCL_SDK_BUILD_OPENGL_SAMPLES "Build OpenCL-OpenGL interop sample code" OFF)
+cmake_dependent_option(OPENCL_SDK_BUILD_VULKAN_SAMPLES "Build OpenCL-Vulkan interop sample code" OFF)
 cmake_dependent_option(OPENCL_SDK_TEST_SAMPLES "Add CTest to samples (where applicable)" ON OPENCL_SDK_BUILD_SAMPLES OFF)
 
 option(OPENCL_SDK_BUILD_CLINFO "Build clinfo utility" ON)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ If CMake is not provided by your build system or OS package manager, please cons
 
 ### Example Build
 
-For most builds, the following steps may be used to build the OpenCL SDK.
-These build steps work on both Windows and Linux:
+In most cases, the following steps may be used to build the OpenCL SDK.
 
 1. Clone this repo and update submodules:
 
@@ -64,7 +63,7 @@ These build steps work on both Windows and Linux:
 
    Or, build the OpenCL SDK using the generated build files directly.
 
-To customize the build, the following CMake variables are supported.
+To customize a build, the following CMake variables are supported.
 To specify one of these variables via the command line generator, use the CMake syntax `-D<variable>=<value>`.
 See your CMake documentation for more details.
 

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ See your CMake documentation for more details.
 | OPENCL_SDK_BUILD_UTILITY_LIBRARIES | BOOL | Enables building OpenCL SDK utility libraries.  Default: `TRUE`
 | OPENCL_SDK_BUILD_SAMPLES | BOOL | Enables building OpenCL SDK samples.  Default: `TRUE`
 | OPENCL_SDK_BUILD_OPENGL_SAMPLES | BOOL | Enables building OpenCL SDK samples that interoperate with OpenGL.  Default: `FALSE`
-| OPENCL_SDK_BUILD_VULKAN_SAMPLES | BOOL | Enables building OpenCL SDK samples that interoperate with Vulkan.  Default: `TRUE`
+| OPENCL_SDK_BUILD_VULKAN_SAMPLES | BOOL | Enables building OpenCL SDK samples that interoperate with Vulkan.  Default: `FALSE`
 | OPENCL_SDK_TEST_SAMPLES | BOOL | Enables a target to test the OpenCL SDK samples.  Default: `TRUE`

--- a/README.md
+++ b/README.md
@@ -40,29 +40,40 @@ If CMake is not provided by your build system or OS package manager, please cons
 
 ### Example Build
 
-> The example build guide uses [Vcpkg](https://vcpkg.io/en/index.html) to fetch all dependencies. Note that Vcpkg is _not_ a requirement and is only used for convenience. One may provide dependencies through any other CMake mechanism. For details on how to install Vcpkg, refer to its [Getting Started Guide](https://vcpkg.io/en/getting-started.html). The example build assumes targeting 64-bit Windows.
+For most builds, the following steps may be used to build the OpenCL SDK.
+These build steps work on both Windows and Linux:
 
-1. Clone this repo with the rest of the OpenCL SDK components:
+1. Clone this repo and update submodules:
 
-       git clone https://github.com/KhronosGroup/OpenCL-SDK.git
-       git submodule init
-       git submodule update
+        git clone https://github.com/KhronosGroup/OpenCL-SDK.git
+        git submodule init
+        git submodule update
 
-1. Build and install SDK with samples and no downstream unit tests:
+2. Create a "build" directory:
 
-       cmake -D BUILD_TESTING=OFF \
-             -D BUILD_DOCS=OFF \
-             -D BUILD_EXAMPLES=OFF \
-             -D BUILD_TESTS=OFF \
-             -D OPENCL_SDK_BUILD_SAMPLES=ON \
-             -D OPENCL_SDK_TEST_SAMPLES=OFF \
-             -D CMAKE_TOOLCHAIN_FILE=/vcpkg/install/root/scripts/buildsystems/vcpkg.cmake \
-             -D CMAKE_BUILD_TYPE=Release \
-             -B ./OpenCL-SDK/build -S ./OpenCL-SDK
-       cmake --build ./OpenCL-SDK/build --target install
+        mkdir build
+        cd build
 
-Samples that make use of OpenGL interop are disabled by default to reduce
-the number of dependencies for most users. They can be enabled using the
-`OPENCL_SDK_BUILD_OPENGL_SAMPLES` CMake option.
+3. Generate build files inside of the "build" directory:
 
-_(Note: on Linux, paths to dependent libraries are automatically handled by RPATH in both the build and install tree. On Windows, all DLLs have to be on the `PATH`. Vcpkg copies dependent DLLs to the build tree, but in order to do the same in the install tree, a sufficiently new CMake version is required. CMake 3.21 introduces `install(IMPORTED_RUNTIME_ARTIFACTS)`.)_
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+
+4. Build the OpenCL SDK and copy files to an "install" directory:
+
+        cmake --build . --target install --config Release
+
+   Or, build the OpenCL SDK using the generated build files directly.
+
+To customize the build, the following CMake variables are supported.
+To specify one of these variables via the command line generator, use the CMake syntax `-D<variable>=<value>`.
+See your CMake documentation for more details.
+
+| Variable | Type | Description |
+|:---------|:-----|:------------|
+| CMAKE_BUILD_TYPE | STRING | Specifies the build type.  Does not affect multi-configuration generators, such as Visual Studio solution files.
+| CMAKE_INSTALL_PREFIX | PATH | Install directory prefix.
+| OPENCL_SDK_BUILD_UTILITY_LIBRARIES | BOOL | Enables building OpenCL SDK utility libraries.  Default: `TRUE`
+| OPENCL_SDK_BUILD_SAMPLES | BOOL | Enables building OpenCL SDK samples.  Default: `TRUE`
+| OPENCL_SDK_BUILD_OPENGL_SAMPLES | BOOL | Enables building OpenCL SDK samples that interoperate with OpenGL.  Default: `FALSE`
+| OPENCL_SDK_BUILD_VULKAN_SAMPLES | BOOL | Enables building OpenCL SDK samples that interoperate with Vulkan.  Default: `TRUE`
+| OPENCL_SDK_TEST_SAMPLES | BOOL | Enables a target to test the OpenCL SDK samples.  Default: `TRUE`


### PR DESCRIPTION
The current README build instructions are more complicated than they need to be.  Much simpler build instructions can be used in most cases.  So, document the simpler build instructions, instead.

Additionally:
* Document the OpenCL SDK CMake variables that may be used to control the build.
* Disable samples that require Vulkan by default, to reduce build dependencies.  Note that OpenGL samples were already disabled by default.
* Add CI configs to test the simple README build instructions on Windows, Linux, and Mac.

see: #70