### PR TITLE
Fix CL_INVALID_WORK_ITEM_SIZE for "reduce" test

### DIFF
--- a/samples/core/reduce/main.c
+++ b/samples/core/reduce/main.c
@@ -386,6 +386,15 @@ int main(int argc, char *argv[])
     OCLERROR_RET(clGetDeviceInfo(device, CL_DEVICE_LOCAL_MEM_SIZE,
                                  sizeof(cl_ulong), &loc_mem, NULL),
                  error, red);
+
+    // Ensure WGS is valid for this device
+    size_t max_wi_dims[3];
+    OCLERROR_RET(clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                                 sizeof(max_wi_dims), max_wi_dims, NULL),
+                 error, red);
+
+    wgs = wgs > max_wi_dims[0] ? max_wi_dims[0] : wgs;
+
     while (loc_mem < wgs * 2 * sizeof(cl_int)) wgs -= psm;
 
     if (wgs == 0)

--- a/samples/core/reduce/main.cpp
+++ b/samples/core/reduce/main.cpp
@@ -175,11 +175,14 @@ int main(int argc, char* argv[])
             cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::LocalSpaceArg,
                               cl_ulong, cl_int>(program, "reduce");
 
-        // Query maximum supported WGS of kernel on device based on private mem
-        // (register) constraints
-        auto wgs =
+        // Query kernel- and device-specific limits
+        size_t kernel_wgs =
             reduce.getKernel().getWorkGroupInfo<CL_KERNEL_WORK_GROUP_SIZE>(
                 device);
+        size_t device_wi_x = device.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>()[0];
+
+        // Clamp work-group size to both limits
+        size_t wgs = std::min(kernel_wgs, device_wi_x);
 
         // Further constrain (reduce) WGS based on shared mem size on device
         while (device.getInfo<CL_DEVICE_LOCAL_MEM_SIZE>()
@@ -191,7 +194,7 @@ int main(int argc, char* argv[])
 
         if (wgs == 0)
             throw std::runtime_error{
-                "Not enough local memory to serve a single sub-group."
+                "Not enough local memory to serve a single work-group."
             };
 
         cl_ulong factor = wgs * 2;


### PR DESCRIPTION
This PR fixes issues in the `reduce` sample where the chosen work-group size (WGS)
could exceed the device’s per-dimension maximum (`CL_DEVICE_MAX_WORK_ITEM_SIZES[0]`),
causing `clEnqueueNDRangeKernel` to fail with `CL_INVALID_WORK_GROUP_SIZE`.

The `reduce` sample has two implementations (C and C++), and both required fixes:

- **C version**: The first patch ensures the kernel is launched with a valid WGS by
  clamping against the device’s maximum.
- **C++ version**: The second patch applies the same clamping logic to the C++ `reduce.cpp`
  application, ensuring consistent behavior.

Together, these patches make both variants of the `reduce` sample more robust and
portable across a wider range of OpenCL devices.

Signed-off-by: Xin Jin <xin.jin@arm.com>